### PR TITLE
Add tests and fixes for AWS helpers

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,13 +1,24 @@
 FROM ubuntu:16.04
 MAINTAINER Gruntwork <info@gruntwork.io>
 
-# Install Bats
+# Install basic dependencies
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
-    apt-get install -y software-properties-common && \
+    apt-get install -y vim python-pip jq sudo curl
+
+# Install Bats
+RUN apt-get install -y software-properties-common && \
     add-apt-repository ppa:duggan/bats && \
     DEBIAN_FRONTEND=noninteractive apt-get update && \
     apt-get install -y bats
 
-# Install other basic dependencies
-RUN apt-get install -y python-pip jq sudo && \
-    pip install awscli --upgrade --user
+# Install AWS CLI
+RUN pip install awscli --upgrade --user
+
+# Install moto: https://github.com/spulec/moto
+RUN pip install flask moto moto[server]
+
+# Install tools we'll need to create a mock EC2 metadata server
+RUN apt-get install -y net-tools iptables
+
+# Copy mock AWS CLI into the PATH
+COPY ./aws-local.sh /usr/local/bin/aws-local.sh

--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -21,4 +21,4 @@ RUN pip install flask moto moto[server]
 RUN apt-get install -y net-tools iptables
 
 # Copy mock AWS CLI into the PATH
-COPY ./aws-local.sh /usr/local/bin/aws-local.sh
+COPY ./aws-local.sh /usr/local/bin/aws

--- a/.circleci/aws-local.sh
+++ b/.circleci/aws-local.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# A wrapper script for the AWS CLI that redirects all calls to localhost:5000 so that they go to moto instead of the
+# real AWS servers. This script should be installed in the PATH so it gets called instead of the real AWS CLI, and this
+# script will, in turn, call the real AWS CLI.
+
+set -e
+
+# Set mock values so the AWS CLI doesn't complain
+export AWS_ACCESS_KEY_ID="mock-for-testing"
+export AWS_SECRET_ACCESS_KEY="mock-for-testing"
+export AWS_DEFAULT_REGION="us-east-1"
+
+# We assume that the AWS CLI has been installed by pip into this path
+readonly REAL_AWS_CLI="$HOME/.local/bin/aws"
+
+"$REAL_AWS_CLI" --endpoint-url=http://localhost:5000 "$@"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,11 @@
 version: 2
 jobs:
   build:
-    docker:
-      - image: gruntwork/bash-commons-circleci-tests
+    # We need to run Docker Compose with privileged settings, which isn't supported by CircleCI's Docker executor, so
+    # we have to use the machine executor instead.
+    machine: true
     steps:
       - checkout
-      - run: bats test
+      - run: |
+          cd test
+          docker-compose up

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@
 build/
 */build/
 out/
+
+# Python
+*.pyc

--- a/test/aws-cli.bats
+++ b/test/aws-cli.bats
@@ -1,0 +1,144 @@
+#!/usr/bin/env bats
+
+source "$BATS_TEST_DIRNAME/../modules/bash-commons/src/aws.sh"
+load "test-helper"
+load "aws-helper"
+
+readonly MOTO_TMP_DIR="/tmp/moto"
+readonly MOTO_PID_FILE_PATH="$MOTO_TMP_DIR/moto.pid"
+
+function setup {
+  mkdir -p "$MOTO_TMP_DIR"
+
+  # Start moto server if it isn't already running
+  if [[ ! -f "$MOTO_PID_FILE_PATH" ]]; then
+    moto_server &
+    echo "$!" > "$MOTO_PID_FILE_PATH"
+
+    # Sleep a bit to give moto a chance to start
+    sleep 1
+  fi
+}
+
+function teardown {
+  # Stop moto if it's running
+  if [[ -f "$MOTO_PID_FILE_PATH" ]]; then
+    local readonly pid=$(cat "$MOTO_PID_FILE_PATH")
+    kill "$pid" 2>&1 > /dev/null
+    rm -f "$MOTO_PID_FILE_PATH"
+
+    # Sleep a bit to give moto a chance to stop
+    sleep 1
+  fi
+}
+
+@test "aws_get_instance_tags empty" {
+  run aws_get_instance_tags "fake-id" "us-east-1"
+  assert_success
+
+  local readonly expected=$(cat <<END_HEREDOC
+{
+  "Tags": []
+}
+END_HEREDOC
+)
+
+  assert_output_json "$expected"
+}
+
+@test "aws_get_instance_tags non-empty" {
+  local readonly tag_key="foo"
+  local readonly tag_value="bar"
+
+  local instance_id
+  instance_id=$(create_mock_instance_with_tags "$tag_key" "$tag_value")
+
+  run aws_get_instance_tags "$instance_id" "us-east-1"
+  assert_success
+
+  local readonly expected=$(cat <<END_HEREDOC
+{
+   "Tags": [
+     {
+       "ResourceType": "instance",
+       "ResourceId": "$instance_id",
+       "Value": "$tag_value",
+       "Key": "$tag_key"
+     }
+   ]
+ }
+END_HEREDOC
+)
+
+  assert_output_json "$expected"
+}
+
+@test "aws_describe_asg empty" {
+  run aws_describe_asg "fake-asg-name" "us-east-1"
+  assert_success
+
+  local readonly expected=$(cat <<END_HEREDOC
+{
+  "AutoScalingGroups": []
+}
+END_HEREDOC
+)
+
+  assert_output_json "$expected"
+}
+
+@test "aws_describe_asg non-empty" {
+  local readonly asg_name="foo"
+  local readonly min_size=1
+  local readonly max_size=3
+  local readonly region="us-east-1"
+  local readonly azs="${region}a"
+
+  create_mock_asg "$asg_name" "$min_size" "$max_size" "$azs"
+
+  run aws_describe_asg "$asg_name" "$region"
+  assert_success
+
+  local actual_asg_name
+  actual_asg_name=$(echo "$output" | jq -r '.AutoScalingGroups[0].AutoScalingGroupName')
+  assert_equal "$asg_name" "$actual_asg_name"
+
+  local actual_min_size
+  actual_min_size=$(echo "$output" | jq -r '.AutoScalingGroups[0].MinSize')
+  assert_equal "$min_size" "$actual_min_size"
+
+  local actual_max_size
+  actual_max_size=$(echo "$output" | jq -r '.AutoScalingGroups[0].MaxSize')
+  assert_equal "$max_size" "$actual_max_size"
+}
+
+@test "aws_describe_instances_in_asg empty" {
+  run aws_describe_instances_in_asg "fake-asg-name" "us-east-1"
+  assert_success
+
+  local readonly expected=$(cat <<END_HEREDOC
+{
+  "Reservations": []
+}
+END_HEREDOC
+)
+
+  assert_output_json "$expected"
+}
+
+@test "aws_describe_instances_in_asg non-empty" {
+  local readonly asg_name="foo"
+  local readonly min_size=1
+  local readonly max_size=3
+  local readonly region="us-east-1"
+  local readonly azs="${region}a"
+
+  create_mock_asg "$asg_name" "$min_size" "$max_size" "$azs"
+
+  run aws_describe_instances_in_asg "$asg_name" "$region"
+  assert_success
+
+  local num_instances
+  num_instances=$(echo "$output" | jq -r '.Reservations | length')
+  assert_greater_than "$num_instances" 0
+}

--- a/test/aws-cli.bats
+++ b/test/aws-cli.bats
@@ -4,32 +4,12 @@ source "$BATS_TEST_DIRNAME/../modules/bash-commons/src/aws.sh"
 load "test-helper"
 load "aws-helper"
 
-readonly MOTO_TMP_DIR="/tmp/moto"
-readonly MOTO_PID_FILE_PATH="$MOTO_TMP_DIR/moto.pid"
-
 function setup {
-  mkdir -p "$MOTO_TMP_DIR"
-
-  # Start moto server if it isn't already running
-  if [[ ! -f "$MOTO_PID_FILE_PATH" ]]; then
-    moto_server &
-    echo "$!" > "$MOTO_PID_FILE_PATH"
-
-    # Sleep a bit to give moto a chance to start
-    sleep 1
-  fi
+  start_moto
 }
 
 function teardown {
-  # Stop moto if it's running
-  if [[ -f "$MOTO_PID_FILE_PATH" ]]; then
-    local readonly pid=$(cat "$MOTO_PID_FILE_PATH")
-    kill "$pid" 2>&1 > /dev/null
-    rm -f "$MOTO_PID_FILE_PATH"
-
-    # Sleep a bit to give moto a chance to stop
-    sleep 1
-  fi
+  stop_moto
 }
 
 @test "aws_get_instance_tags empty" {

--- a/test/aws-ec2-metadata.bats
+++ b/test/aws-ec2-metadata.bats
@@ -1,0 +1,124 @@
+#!/usr/bin/env bats
+
+readonly bash_commons_src_path="$BATS_TEST_DIRNAME/../modules/bash-commons/src"
+source "$bash_commons_src_path/aws.sh"
+source "$bash_commons_src_path/string.sh"
+load "test-helper"
+
+readonly EC2_METADATA_MOCK_APP_PATH="$BATS_TEST_DIRNAME/ec2-metadata-mock/ec2-metadata-mock.py"
+readonly EC2_METADATA_MOCK_TMP_DIR="/tmp/ec2-metadata-mock"
+readonly EC2_METADATA_MOCK_PID_PATH="$EC2_METADATA_MOCK_TMP_DIR/ec2-metadata-mock.pid"
+readonly EC2_METADATA_MOCK_LOG_FILE_PATH="$EC2_METADATA_MOCK_TMP_DIR/ec2-metadata-mock.log"
+
+# Set env vars for ec2-metadata-mock
+export meta_data_local_ipv4="11.22.33.44"
+export meta_data_public_ipv4="55.66.77.88"
+export meta_data_local_hostname="ip-10-251-50-12.ec2.internal"
+export meta_data_public_hostname="ec2-203-0-113-25.compute-1.amazonaws.com"
+export meta_data_instance_id="i-1234567890abcdef0"
+
+readonly mock_region="us-west-1"
+export meta_data_placement__availability_zone="${mock_region}b"
+export dynamic_data_instance_identity__document=$(cat <<END_HEREDOC
+{
+  "devpayProductCodes" : null,
+  "marketplaceProductCodes" : [ "1abc2defghijklm3nopqrs4tu" ],
+  "availabilityZone" : "$meta_data_placement__availability_zone",
+  "privateIp" : "$meta_data_local_ipv4",
+  "version" : "2017-09-30",
+  "instanceId" : "$meta_data_instance_id",
+  "billingProducts" : null,
+  "instanceType" : "t2.micro",
+  "accountId" : "123456789012",
+  "imageId" : "ami-5fb8c835",
+  "pendingTime" : "2016-11-19T16:32:11Z",
+  "architecture" : "x86_64",
+  "kernelId" : null,
+  "ramdiskId" : null,
+  "region" : "$mock_region"
+}
+END_HEREDOC
+)
+
+# Configure the server so we can run a mock EC2 metadata endpoint on port 80 with the metadata endpoint's special IP.
+function setup {
+  local config
+  config=$(ifconfig)
+
+  mkdir -p "$EC2_METADATA_MOCK_TMP_DIR"
+
+  # Use ifconfig and iptables to allow us to run a mock server on 169.254.169.254 and on port 80. These steps are
+  # based on https://github.com/NYTimes/mock-ec2-metadata. Note #1: we can't use that project directly as it doesn't
+  # support most EC2 metadata endpoints. Note #2: try to make this code idempotent so we don't try to create the same
+  # configuration multiple times.
+  if ! string_multiline_contains "$config" "lo:1"; then
+    ifconfig lo:1 inet 169.254.169.254 netmask 255.255.255.255 up
+    echo 1 > /proc/sys/net/ipv4/ip_forward
+    iptables -t nat -A OUTPUT -p tcp -d 169.254.169.254/32 --dport 80  -j DNAT --to-destination 169.254.169.254:8111
+    iptables-save
+  fi
+
+  # Start ec2-metadata-mock if it isn't already running
+  if [[ ! -f "$EC2_METADATA_MOCK_PID_PATH" ]]; then
+    FLASK_APP="$EC2_METADATA_MOCK_APP_PATH" flask run --host=0.0.0.0 --port=8111 2>&1 > "$EC2_METADATA_MOCK_LOG_FILE_PATH" &
+    echo "$!" > "$EC2_METADATA_MOCK_PID_PATH"
+
+    # Sleep a bit to give Flask a chance to start
+    sleep 1
+  fi
+}
+
+function teardown {
+  # Stop ec2-metadata-mock if it's running
+  if [[ -f "$EC2_METADATA_MOCK_PID_PATH" ]]; then
+    local readonly pid=$(cat "$EC2_METADATA_MOCK_PID_PATH")
+    kill "$pid" 2>&1 > "$EC2_METADATA_MOCK_LOG_FILE_PATH"
+    rm -f "$EC2_METADATA_MOCK_PID_PATH"
+
+    # Sleep a bit to give Flask a chance to stop
+    sleep 1
+  fi
+}
+
+@test "aws_get_instance_private_ip" {
+  run aws_get_instance_private_ip
+  assert_success
+  assert_output "$meta_data_local_ipv4"
+}
+
+@test "aws_get_instance_public_ip" {
+  run aws_get_instance_public_ip
+  assert_success
+  assert_output "$meta_data_public_ipv4"
+}
+
+@test "aws_get_instance_private_hostname" {
+  run aws_get_instance_private_hostname
+  assert_success
+  assert_output "$meta_data_local_hostname"
+}
+
+@test "aws_get_instance_public_hostname" {
+  run aws_get_instance_public_hostname
+  assert_success
+  assert_output "$meta_data_public_hostname"
+}
+
+@test "aws_get_instance_id" {
+  run aws_get_instance_id
+  assert_success
+  assert_output "$meta_data_instance_id"
+}
+
+@test "aws_get_instance_region" {
+  run aws_get_instance_region
+  assert_success
+  assert_output "$mock_region"
+}
+
+@test "aws_get_ec2_instance_availability_zone" {
+  run aws_get_ec2_instance_availability_zone
+  assert_success
+  assert_output "$meta_data_placement__availability_zone"
+}
+

--- a/test/aws-ec2-metadata.bats
+++ b/test/aws-ec2-metadata.bats
@@ -1,113 +1,60 @@
 #!/usr/bin/env bats
 
-readonly bash_commons_src_path="$BATS_TEST_DIRNAME/../modules/bash-commons/src"
-source "$bash_commons_src_path/aws.sh"
-source "$bash_commons_src_path/string.sh"
+source "$BATS_TEST_DIRNAME/../modules/bash-commons/src/aws.sh"
 load "test-helper"
+load "aws-helper"
 
-readonly EC2_METADATA_MOCK_APP_PATH="$BATS_TEST_DIRNAME/ec2-metadata-mock/ec2-metadata-mock.py"
-readonly EC2_METADATA_MOCK_TMP_DIR="/tmp/ec2-metadata-mock"
-readonly EC2_METADATA_MOCK_PID_PATH="$EC2_METADATA_MOCK_TMP_DIR/ec2-metadata-mock.pid"
-readonly EC2_METADATA_MOCK_LOG_FILE_PATH="$EC2_METADATA_MOCK_TMP_DIR/ec2-metadata-mock.log"
-
-# Set env vars for ec2-metadata-mock
-export meta_data_local_ipv4="11.22.33.44"
-export meta_data_public_ipv4="55.66.77.88"
-export meta_data_local_hostname="ip-10-251-50-12.ec2.internal"
-export meta_data_public_hostname="ec2-203-0-113-25.compute-1.amazonaws.com"
-export meta_data_instance_id="i-1234567890abcdef0"
-
+readonly local_ipv4="11.22.33.44"
+readonly public_ipv4="55.66.77.88"
+readonly local_hostname="ip-10-251-50-12.ec2.internal"
+readonly public_hostname="ec2-203-0-113-25.compute-1.amazonaws.com"
+readonly instance_id="i-1234567890abcdef0"
 readonly mock_region="us-west-1"
-export meta_data_placement__availability_zone="${mock_region}b"
-export dynamic_data_instance_identity__document=$(cat <<END_HEREDOC
-{
-  "devpayProductCodes" : null,
-  "marketplaceProductCodes" : [ "1abc2defghijklm3nopqrs4tu" ],
-  "availabilityZone" : "$meta_data_placement__availability_zone",
-  "privateIp" : "$meta_data_local_ipv4",
-  "version" : "2017-09-30",
-  "instanceId" : "$meta_data_instance_id",
-  "billingProducts" : null,
-  "instanceType" : "t2.micro",
-  "accountId" : "123456789012",
-  "imageId" : "ami-5fb8c835",
-  "pendingTime" : "2016-11-19T16:32:11Z",
-  "architecture" : "x86_64",
-  "kernelId" : null,
-  "ramdiskId" : null,
-  "region" : "$mock_region"
-}
-END_HEREDOC
-)
+readonly availability_zone="${mock_region}b"
 
-# Configure the server so we can run a mock EC2 metadata endpoint on port 80 with the metadata endpoint's special IP.
 function setup {
-  local config
-  config=$(ifconfig)
-
-  mkdir -p "$EC2_METADATA_MOCK_TMP_DIR"
-
-  # Use ifconfig and iptables to allow us to run a mock server on 169.254.169.254 and on port 80. These steps are
-  # based on https://github.com/NYTimes/mock-ec2-metadata. Note #1: we can't use that project directly as it doesn't
-  # support most EC2 metadata endpoints. Note #2: try to make this code idempotent so we don't try to create the same
-  # configuration multiple times.
-  if ! string_multiline_contains "$config" "lo:1"; then
-    ifconfig lo:1 inet 169.254.169.254 netmask 255.255.255.255 up
-    echo 1 > /proc/sys/net/ipv4/ip_forward
-    iptables -t nat -A OUTPUT -p tcp -d 169.254.169.254/32 --dport 80  -j DNAT --to-destination 169.254.169.254:8111
-    iptables-save
-  fi
-
-  # Start ec2-metadata-mock if it isn't already running
-  if [[ ! -f "$EC2_METADATA_MOCK_PID_PATH" ]]; then
-    FLASK_APP="$EC2_METADATA_MOCK_APP_PATH" flask run --host=0.0.0.0 --port=8111 2>&1 > "$EC2_METADATA_MOCK_LOG_FILE_PATH" &
-    echo "$!" > "$EC2_METADATA_MOCK_PID_PATH"
-
-    # Sleep a bit to give Flask a chance to start
-    sleep 1
-  fi
+  start_ec2_metadata_mock \
+    "$local_ipv4" \
+    "$public_ipv4" \
+    "$local_hostname" \
+    "$public_hostname" \
+    "$instance_id" \
+    "$mock_region" \
+    "$availability_zone"
 }
 
 function teardown {
-  # Stop ec2-metadata-mock if it's running
-  if [[ -f "$EC2_METADATA_MOCK_PID_PATH" ]]; then
-    local readonly pid=$(cat "$EC2_METADATA_MOCK_PID_PATH")
-    kill "$pid" 2>&1 > "$EC2_METADATA_MOCK_LOG_FILE_PATH"
-    rm -f "$EC2_METADATA_MOCK_PID_PATH"
-
-    # Sleep a bit to give Flask a chance to stop
-    sleep 1
-  fi
+  stop_ec2_metadata_mock
 }
 
 @test "aws_get_instance_private_ip" {
   run aws_get_instance_private_ip
   assert_success
-  assert_output "$meta_data_local_ipv4"
+  assert_output "$local_ipv4"
 }
 
 @test "aws_get_instance_public_ip" {
   run aws_get_instance_public_ip
   assert_success
-  assert_output "$meta_data_public_ipv4"
+  assert_output "$public_ipv4"
 }
 
 @test "aws_get_instance_private_hostname" {
   run aws_get_instance_private_hostname
   assert_success
-  assert_output "$meta_data_local_hostname"
+  assert_output "$local_hostname"
 }
 
 @test "aws_get_instance_public_hostname" {
   run aws_get_instance_public_hostname
   assert_success
-  assert_output "$meta_data_public_hostname"
+  assert_output "$public_hostname"
 }
 
 @test "aws_get_instance_id" {
   run aws_get_instance_id
   assert_success
-  assert_output "$meta_data_instance_id"
+  assert_output "$instance_id"
 }
 
 @test "aws_get_instance_region" {
@@ -119,6 +66,6 @@ function teardown {
 @test "aws_get_ec2_instance_availability_zone" {
   run aws_get_ec2_instance_availability_zone
   assert_success
-  assert_output "$meta_data_placement__availability_zone"
+  assert_output "$availability_zone"
 }
 

--- a/test/aws-helper.bash
+++ b/test/aws-helper.bash
@@ -1,5 +1,122 @@
 #!/bin/bash
 
+set -e
+
+source "$BATS_TEST_DIRNAME/../modules/bash-commons/src/string.sh"
+
+readonly MOTO_TMP_DIR="/tmp/moto"
+readonly MOTO_PID_FILE_PATH="$MOTO_TMP_DIR/moto.pid"
+
+readonly EC2_METADATA_MOCK_APP_PATH="$BATS_TEST_DIRNAME/ec2-metadata-mock/ec2-metadata-mock.py"
+readonly EC2_METADATA_MOCK_TMP_DIR="/tmp/ec2-metadata-mock"
+readonly EC2_METADATA_MOCK_PID_PATH="$EC2_METADATA_MOCK_TMP_DIR/ec2-metadata-mock.pid"
+readonly EC2_METADATA_MOCK_LOG_FILE_PATH="$EC2_METADATA_MOCK_TMP_DIR/ec2-metadata-mock.log"
+
+function start_ec2_metadata_mock {
+  # Set env vars for ec2-metadata-mock
+  export meta_data_local_ipv4="$1"
+  export meta_data_public_ipv4="$2"
+  export meta_data_local_hostname="$3"
+  export meta_data_public_hostname="$4"
+  export meta_data_instance_id="$5"
+  local readonly region="$6"
+  export meta_data_placement__availability_zone="$7"
+  export dynamic_data_instance_identity__document=$(cat <<END_HEREDOC
+{
+  "devpayProductCodes" : null,
+  "marketplaceProductCodes" : [ "1abc2defghijklm3nopqrs4tu" ],
+  "availabilityZone" : "$meta_data_placement__availability_zone",
+  "privateIp" : "$meta_data_local_ipv4",
+  "version" : "2017-09-30",
+  "instanceId" : "$meta_data_instance_id",
+  "billingProducts" : null,
+  "instanceType" : "t2.micro",
+  "accountId" : "123456789012",
+  "imageId" : "ami-5fb8c835",
+  "pendingTime" : "2016-11-19T16:32:11Z",
+  "architecture" : "x86_64",
+  "kernelId" : null,
+  "ramdiskId" : null,
+  "region" : "$region"
+}
+END_HEREDOC
+)
+
+  local config
+  config=$(ifconfig)
+
+  mkdir -p "$EC2_METADATA_MOCK_TMP_DIR"
+
+  # Use ifconfig and iptables to allow us to run a mock server on 169.254.169.254 and on port 80. These steps are
+  # based on https://github.com/NYTimes/mock-ec2-metadata. Note #1: we can't use that project directly as it doesn't
+  # support most EC2 metadata endpoints. Note #2: try to make this code idempotent so we don't try to create the same
+  # configuration multiple times.
+  if ! string_multiline_contains "$config" "lo:1"; then
+    ifconfig lo:1 inet 169.254.169.254 netmask 255.255.255.255 up
+    echo 1 > /proc/sys/net/ipv4/ip_forward
+    iptables -t nat -A OUTPUT -p tcp -d 169.254.169.254/32 --dport 80  -j DNAT --to-destination 169.254.169.254:8111
+    iptables-save
+  fi
+
+  # Start ec2-metadata-mock if it isn't already running
+  if [[ ! -f "$EC2_METADATA_MOCK_PID_PATH" ]]; then
+    FLASK_APP="$EC2_METADATA_MOCK_APP_PATH" flask run --host=0.0.0.0 --port=8111 2>&1  > "$EC2_METADATA_MOCK_LOG_FILE_PATH" &
+    echo "$!" > "$EC2_METADATA_MOCK_PID_PATH"
+
+    # Sleep a bit to give Flask a chance to start
+    sleep 1
+  fi
+}
+
+function stop_ec2_metadata_mock {
+  # Stop ec2-metadata-mock if it's running
+  if [[ -f "$EC2_METADATA_MOCK_PID_PATH" ]]; then
+    local readonly pid=$(cat "$EC2_METADATA_MOCK_PID_PATH")
+    kill "$pid" 2>&1 > "$EC2_METADATA_MOCK_LOG_FILE_PATH"
+    rm -f "$EC2_METADATA_MOCK_PID_PATH"
+
+    # Sleep a bit to give Flask a chance to stop
+    sleep 1
+  fi
+}
+
+# Source the mock version of aws.sh to override the real one so we don't depend on EC2 metadata. For some reason, with
+# bats, trying to run both moto and the mock ec2 metadata services in the background causes the latter to hang. This
+# may be related to https://github.com/sstephenson/bats/issues/80, but none of the workarounds seem to help, so for now,
+# tests that need both should load the real moto, but use this mock for aws.sh.
+function load_aws_mock {
+  export mock_instance_tags="$1"
+  export mock_asg="$2"
+  export mock_instances_in_asg="$3"
+
+  source "$BATS_TEST_DIRNAME/aws-mock/aws.sh"
+}
+
+function start_moto {
+  mkdir -p "$MOTO_TMP_DIR"
+
+  # Start moto server if it isn't already running
+  if [[ ! -f "$MOTO_PID_FILE_PATH" ]]; then
+    moto_server &
+    echo "$!" > "$MOTO_PID_FILE_PATH"
+
+    # Sleep a bit to give moto a chance to start
+    sleep 1
+  fi
+}
+
+function stop_moto {
+  # Stop moto if it's running
+  if [[ -f "$MOTO_PID_FILE_PATH" ]]; then
+    local readonly pid=$(cat "$MOTO_PID_FILE_PATH")
+    kill "$pid" 2>&1 > /dev/null
+    rm -f "$MOTO_PID_FILE_PATH"
+
+    # Sleep a bit to give moto a chance to stop
+    sleep 1
+  fi
+}
+
 function create_mock_instance_with_tags {
   local readonly tag_key="$1"
   local readonly tag_value="$2"

--- a/test/aws-helper.bash
+++ b/test/aws-helper.bash
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+function create_mock_instance_with_tags {
+  local readonly tag_key="$1"
+  local readonly tag_value="$2"
+
+  local mock_instance
+  mock_instance=$(aws ec2 run-instances)
+
+  local instance_id
+  instance_id=$(echo "$mock_instance" | jq -r '.Instances[0].InstanceId')
+
+  aws ec2 create-tags --resources "$instance_id" --tags Key="$tag_key",Value="$tag_value"
+
+  echo -n "$instance_id"
+}
+
+function create_mock_asg {
+  local readonly asg_name="$1"
+  local readonly min_size="$2"
+  local readonly max_size="$3"
+  local readonly azs="$4"
+
+  aws autoscaling create-launch-configuration --launch-configuration-name "$asg_name"
+  aws autoscaling create-auto-scaling-group --auto-scaling-group-name "$asg_name" --min-size "$min_size" --max-size "$max_size" --availability-zones "$azs" --launch-configuration-name "$asg_name"
+}

--- a/test/aws-mock/aws.sh
+++ b/test/aws-mock/aws.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# A mock version of aws.sh that returns hard-coded values and values from environment variables instead of making real
+# API calls to AWS or the EC2 metadata service.
+
+set -e
+
+# Get the private IP address for this EC2 Instance
+function aws_get_instance_private_ip {
+  echo -n "11.22.33.44"
+}
+
+# Get the public IP address for this EC2 Instance
+function aws_get_instance_public_ip {
+  echo -n "55.66.77.88"
+}
+
+# Get the private hostname for this EC2 Instance
+function aws_get_instance_private_hostname {
+  echo -n "ip-10-251-50-12.ec2.internal"
+}
+
+# Get the public hostname for this EC2 Instance
+function aws_get_instance_public_hostname {
+  echo -n "ec2-203-0-113-25.compute-1.amazonaws.com"
+}
+
+# Get the ID of this EC2 Instance
+function aws_get_instance_id {
+  echo -n "i-1234567890abcdef0"
+}
+
+# Get the region this EC2 Instance is deployed in
+function aws_get_instance_region {
+  echo -n "us-east-1"
+}
+
+# Get the availability zone this EC2 Instance is deployed in
+function aws_get_ec2_instance_availability_zone {
+  echo -n "us-east-1b"
+}
+
+# Get the tags for the given instance and region. Returns JSON from the AWS CLI's describe-tags command.
+function aws_get_instance_tags {
+  local readonly instance_id="$1"
+  local readonly instance_region="$2"
+
+  echo -n "$mock_instance_tags"
+}
+
+# Describe the given ASG in the given region. Returns JSON from the AWS CLI's describe-auto-scaling-groups command.
+function aws_describe_asg {
+  local readonly asg_name="$1"
+  local readonly aws_region="$2"
+
+  echo -n "$mock_asg"
+}
+
+# Describe the EC2 Instances in the given ASG in the given region. Returns JSON from the AWS CLI's describe-instances
+# command
+function aws_describe_instances_in_asg {
+  local readonly asg_name="$1"
+  local readonly aws_region="$2"
+
+  echo -n "$mock_instances_in_asg"
+}

--- a/test/aws-wrapper.bats
+++ b/test/aws-wrapper.bats
@@ -1,0 +1,1314 @@
+#!/usr/bin/env bats
+
+source "$BATS_TEST_DIRNAME/../modules/bash-commons/src/aws-wrapper.sh"
+load "test-helper"
+load "aws-helper"
+
+@test "aws_wrapper_get_asg_name ASG tag only" {
+  local readonly asg_name="foo"
+  local reaodnly max_retries=1
+  local readonly sleep_between_retries=0
+  local readonly tags=$(cat <<END_HEREDOC
+{
+   "Tags": [
+     {
+       "ResourceType": "instance",
+       "ResourceId": "i-1234567890abcdef0",
+       "Value": "asg_name",
+       "Key": "aws:autoscaling:groupName"
+     }
+   ]
+ }
+END_HEREDOC
+)
+
+  load_aws_mock "$tags" "" ""
+
+  local out
+  out=$(aws_wrapper_get_asg_name "$max_retries" "$sleep_between_retries")
+
+  assert_success
+  assert_equal "foo" "$asg_name"
+}
+
+@test "aws_wrapper_get_asg_name ASG tag and other tags" {
+  local readonly asg_name="foo"
+  local reaodnly max_retries=1
+  local readonly sleep_between_retries=0
+  local readonly tags=$(cat <<END_HEREDOC
+{
+   "Tags": [
+     {
+       "ResourceType": "instance",
+       "ResourceId": "i-1234567890abcdef0",
+       "Value": "bar",
+       "Key": "foo"
+     },
+     {
+       "ResourceType": "instance",
+       "ResourceId": "i-1234567890abcdef0",
+       "Value": "asg_name",
+       "Key": "aws:autoscaling:groupName"
+     },
+     {
+       "ResourceType": "instance",
+       "ResourceId": "i-1234567890abcdef0",
+       "Value": "blah",
+       "Key": "baz"
+     }
+   ]
+ }
+END_HEREDOC
+)
+
+  load_aws_mock "$tags" "" ""
+
+  local out
+  out=$(aws_wrapper_get_asg_name "$max_retries" "$sleep_between_retries")
+
+  assert_success
+  assert_equal "foo" "$asg_name"
+}
+
+@test "aws_wrapper_get_asg_name no tags" {
+  local reaodnly max_retries=1
+  local readonly sleep_between_retries=0
+  local readonly tags=$(cat <<END_HEREDOC
+{
+   "Tags": []
+ }
+END_HEREDOC
+)
+
+  load_aws_mock "$tags" "" ""
+
+  run aws_wrapper_get_asg_name "$max_retries" "$sleep_between_retries"
+
+  assert_failure
+}
+
+@test "aws_wrapper_get_asg_name no ASG tags" {
+  local reaodnly max_retries=1
+  local readonly sleep_between_retries=0
+  local readonly tags=$(cat <<END_HEREDOC
+{
+   "Tags": [
+     {
+       "ResourceType": "instance",
+       "ResourceId": "i-1234567890abcdef0",
+       "Value": "bar",
+       "Key": "foo"
+     }
+   ]
+ }
+END_HEREDOC
+)
+  load_aws_mock "$tags" "" ""
+
+  run aws_wrapper_get_asg_name "$max_retries" "$sleep_between_retries"
+
+  assert_failure
+}
+
+@test "aws_wrapper_get_instance_tag no tags" {
+  local reaodnly max_retries=1
+  local readonly sleep_between_retries=0
+  local readonly tags=$(cat <<END_HEREDOC
+{
+   "Tags": []
+ }
+END_HEREDOC
+)
+
+  load_aws_mock "$tags" "" ""
+
+  run aws_wrapper_get_instance_tag "i-1234567890abcdef0" "us-east-1" "foo" "$max_retries" "$sleep_between_retries"
+
+  assert_failure
+}
+
+@test "aws_wrapper_get_instance_tag no matching tag" {
+  local reaodnly max_retries=1
+  local readonly sleep_between_retries=0
+  local readonly tags=$(cat <<END_HEREDOC
+{
+   "Tags": [
+     {
+       "ResourceType": "instance",
+       "ResourceId": "i-1234567890abcdef0",
+       "Value": "blah",
+       "Key": "baz"
+     }
+   ]
+ }
+END_HEREDOC
+)
+
+  load_aws_mock "$tags" "" ""
+
+  run aws_wrapper_get_instance_tag "i-1234567890abcdef0" "us-east-1" "foo" "$max_retries" "$sleep_between_retries"
+
+  assert_failure
+}
+
+@test "aws_wrapper_get_instance_tag matching tag" {
+  local readonly tag_key="foo"
+  local readonly tag_value="bar"
+  local reaodnly max_retries=1
+  local readonly sleep_between_retries=0
+  local readonly tags=$(cat <<END_HEREDOC
+{
+   "Tags": [
+     {
+       "ResourceType": "instance",
+       "ResourceId": "i-1234567890abcdef0",
+       "Value": "$tag_value",
+       "Key": "$tag_key"
+     }
+   ]
+ }
+END_HEREDOC
+)
+
+  load_aws_mock "$tags" "" ""
+
+  local out
+  out=$(aws_wrapper_get_instance_tag "i-1234567890abcdef0" "us-east-1" "$tag_key" "$max_retries" "$sleep_between_retries")
+
+  assert_success
+  assert_equal "$tag_value" "$out"
+}
+
+@test "aws_wrapper_wait_for_instance_tags one tag" {
+  local reaodnly max_retries=1
+  local readonly sleep_between_retries=0
+  local readonly tags=$(cat <<END_HEREDOC
+{
+   "Tags": [
+     {
+       "ResourceType": "instance",
+       "ResourceId": "i-1234567890abcdef0",
+       "Value": "bar",
+       "Key": "foo"
+     }
+   ]
+ }
+END_HEREDOC
+)
+
+  load_aws_mock "$tags" "" ""
+
+  local out
+  out=$(aws_wrapper_wait_for_instance_tags "i-1234567890abcdef0" "us-east-1" "$max_retries" "$sleep_between_retries")
+
+  assert_success
+  assert_equal "$tags" "$out"
+}
+
+@test "aws_wrapper_wait_for_instance_tags multiple tags" {
+  local reaodnly max_retries=1
+  local readonly sleep_between_retries=0
+  local readonly tags=$(cat <<END_HEREDOC
+{
+   "Tags": [
+     {
+       "ResourceType": "instance",
+       "ResourceId": "i-1234567890abcdef0",
+       "Value": "bar",
+       "Key": "foo"
+     },
+     {
+       "ResourceType": "instance",
+       "ResourceId": "i-1234567890abcdef0",
+       "Value": "blah",
+       "Key": "baz"
+     },
+     {
+       "ResourceType": "instance",
+       "ResourceId": "i-1234567890abcdef0",
+       "Value": "def",
+       "Key": "abc"
+     }
+   ]
+ }
+END_HEREDOC
+)
+
+  load_aws_mock "$tags" "" ""
+
+  local out
+  out=$(aws_wrapper_wait_for_instance_tags "i-1234567890abcdef0" "us-east-1" "$max_retries" "$sleep_between_retries")
+
+  assert_success
+  assert_equal "$tags" "$out"
+}
+
+@test "aws_wrapper_wait_for_instance_tags no tags" {
+  local reaodnly max_retries=1
+  local readonly sleep_between_retries=0
+  local readonly tags=$(cat <<END_HEREDOC
+{
+   "Tags": []
+ }
+END_HEREDOC
+)
+
+  load_aws_mock "$tags" "" ""
+
+  run naws_wrapper_wait_for_instance_tags "i-1234567890abcdef0" "us-east-1" "$max_retries" "$sleep_between_retries"
+
+  assert_failure
+}
+
+@test "aws_wrapper_wait_for_instance_tags no tags" {
+  local reaodnly max_retries=1
+  local readonly sleep_between_retries=0
+  local readonly tags=$(cat <<END_HEREDOC
+{
+   "Tags": []
+ }
+END_HEREDOC
+)
+
+  load_aws_mock "$tags" "" ""
+
+  run naws_wrapper_wait_for_instance_tags "i-1234567890abcdef0" "us-east-1" "$max_retries" "$sleep_between_retries"
+
+  assert_failure
+}
+
+@test "aws_wrapper_get_asg_size ASG exists" {
+  local readonly size=4
+  local reaodnly max_retries=1
+  local readonly sleep_between_retries=0
+  local readonly asg=$(cat <<END_HEREDOC
+{
+    "AutoScalingGroups": [
+        {
+            "AutoScalingGroupARN": "arn:aws:autoscaling:us-west-2:123456789012:autoScalingGroup:930d940e-891e-4781-a11a-7b0acd480f03:autoScalingGroupName/asg-name",
+            "DesiredCapacity": $size,
+            "AutoScalingGroupName": "asg-name",
+            "MinSize": 0,
+            "MaxSize": 10,
+            "LaunchConfigurationName": "my-launch-config",
+            "CreatedTime": "2013-08-19T20:53:25.584Z",
+            "AvailabilityZones": [
+                "us-west-2c"
+            ]
+        }
+    ]
+}
+END_HEREDOC
+)
+
+  load_aws_mock "" "$asg" ""
+
+  local out
+  out=$(aws_wrapper_get_asg_size "asg-name" "us-east-1" "$max_retries" "$sleep_between_retries")
+
+  assert_success
+  assert_equal "$size" "$out"
+}
+
+@test "aws_wrapper_get_asg_size ASG does not exist" {
+  local readonly size=4
+  local reaodnly max_retries=1
+  local readonly sleep_between_retries=0
+  local readonly asg=$(cat <<END_HEREDOC
+{
+    "AutoScalingGroups": []
+}
+END_HEREDOC
+)
+
+  load_aws_mock "" "$asg" ""
+
+  run aws_wrapper_get_asg_size "asg-name" "us-east-1" "$max_retries" "$sleep_between_retries"
+
+  assert_failure
+}
+
+@test "aws_wrapper_wait_for_instances_in_asg ASG size 1" {
+  local readonly size=1
+  local readonly asg_name="asg-name"
+  local reaodnly max_retries=1
+  local readonly sleep_between_retries=0
+
+  local readonly asg=$(cat <<END_HEREDOC
+{
+    "AutoScalingGroups": [
+        {
+            "AutoScalingGroupARN": "arn:aws:autoscaling:us-west-2:123456789012:autoScalingGroup:930d940e-891e-4781-a11a-7b0acd480f03:autoScalingGroupName/$asg_name",
+            "DesiredCapacity": $size,
+            "AutoScalingGroupName": "$asg_name",
+            "MinSize": 0,
+            "MaxSize": 10,
+            "LaunchConfigurationName": "my-launch-config",
+            "CreatedTime": "2013-08-19T20:53:25.584Z",
+            "AvailabilityZones": [
+                "us-west-2c"
+            ]
+        }
+    ]
+}
+END_HEREDOC
+)
+
+  local readonly instances=$(cat <<END_HEREDOC
+{
+  "Reservations": [
+    {
+      "Instances": [
+        {
+          "LaunchTime": "2013-08-19T20:53:25.584Z",
+          "InstanceId": "i-1234567890abcdef0",
+          "PublicIpAddress": "55.66.77.88",
+          "PrivateIpAddress": "11.22.33.44",
+          "PrivateDnsName": "ip-10-251-50-12.ec2.internal",
+          "PublicDnsName": "ec2-203-0-113-25.compute-1.amazonaws.com",
+          "Tags": [
+            {
+              "Value": "$asg_name",
+              "Key": "aws:autoscaling:groupName"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+END_HEREDOC
+)
+
+  load_aws_mock "" "$asg" "$instances"
+
+  local out
+  out=$(aws_wrapper_wait_for_instances_in_asg "$asg_name" "us-east-1" "$max_retries" "$sleep_between_retries")
+
+  assert_success
+  assert_equal "$instances" "$out"
+}
+
+@test "aws_wrapper_wait_for_instances_in_asg ASG size 3" {
+  local readonly size=3
+  local readonly asg_name="asg-name"
+  local reaodnly max_retries=1
+  local readonly sleep_between_retries=0
+
+  local readonly asg=$(cat <<END_HEREDOC
+{
+    "AutoScalingGroups": [
+        {
+            "AutoScalingGroupARN": "arn:aws:autoscaling:us-west-2:123456789012:autoScalingGroup:930d940e-891e-4781-a11a-7b0acd480f03:autoScalingGroupName/$asg_name",
+            "DesiredCapacity": $size,
+            "AutoScalingGroupName": "$asg_name",
+            "MinSize": 0,
+            "MaxSize": 10,
+            "LaunchConfigurationName": "my-launch-config",
+            "CreatedTime": "2013-08-19T20:53:25.584Z",
+            "AvailabilityZones": [
+                "us-west-2c"
+            ]
+        }
+    ]
+}
+END_HEREDOC
+)
+
+  local readonly instances=$(cat <<END_HEREDOC
+{
+  "Reservations": [
+    {
+      "Instances": [
+        {
+          "LaunchTime": "2013-08-19T20:53:25.584Z",
+          "InstanceId": "i-1234567890abcdef0",
+          "PublicIpAddress": "55.66.77.88",
+          "PrivateIpAddress": "11.22.33.44",
+          "PrivateDnsName": "ip-10-251-50-12.ec2.internal",
+          "PublicDnsName": "ec2-203-0-113-25.compute-1.amazonaws.com",
+          "Tags": [
+            {
+              "Value": "$asg_name",
+              "Key": "aws:autoscaling:groupName"
+            }
+          ]
+        },
+        {
+          "LaunchTime": "2013-08-19T20:53:25.584Z",
+          "InstanceId": "i-1234567890abcdef1",
+          "PublicIpAddress": "55.66.77.881",
+          "PrivateIpAddress": "11.22.33.441",
+          "PrivateDnsName": "ip-10-251-50-121.ec2.internal",
+          "PublicDnsName": "ec2-203-0-113-252.compute-1.amazonaws.com",
+          "Tags": [
+            {
+              "Value": "$asg_name",
+              "Key": "aws:autoscaling:groupName"
+            }
+          ]
+        },
+        {
+          "LaunchTime": "2013-08-19T20:53:25.584Z",
+          "InstanceId": "i-1234567890abcdef2",
+          "PublicIpAddress": "55.66.77.882",
+          "PrivateIpAddress": "11.22.33.442",
+          "PrivateDnsName": "ip-10-251-50-121.ec2.internal",
+          "PublicDnsName": "ec2-203-0-113-252.compute-1.amazonaws.com",
+          "Tags": [
+            {
+              "Value": "$asg_name",
+              "Key": "aws:autoscaling:groupName"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+END_HEREDOC
+)
+
+  load_aws_mock "" "$asg" "$instances"
+
+  local out
+  out=$(aws_wrapper_wait_for_instances_in_asg "$asg_name" "us-east-1" "$max_retries" "$sleep_between_retries")
+
+  assert_success
+  assert_equal "$instances" "$out"
+}
+
+@test "aws_wrapper_wait_for_instances_in_asg ASG size 2, 3 available" {
+  local readonly size=2
+  local readonly asg_name="asg-name"
+  local reaodnly max_retries=1
+  local readonly sleep_between_retries=0
+
+  local readonly asg=$(cat <<END_HEREDOC
+{
+    "AutoScalingGroups": [
+        {
+            "AutoScalingGroupARN": "arn:aws:autoscaling:us-west-2:123456789012:autoScalingGroup:930d940e-891e-4781-a11a-7b0acd480f03:autoScalingGroupName/$asg_name",
+            "DesiredCapacity": $size,
+            "AutoScalingGroupName": "$asg_name",
+            "MinSize": 0,
+            "MaxSize": 10,
+            "LaunchConfigurationName": "my-launch-config",
+            "CreatedTime": "2013-08-19T20:53:25.584Z",
+            "AvailabilityZones": [
+                "us-west-2c"
+            ]
+        }
+    ]
+}
+END_HEREDOC
+)
+
+  local readonly instances=$(cat <<END_HEREDOC
+{
+  "Reservations": [
+    {
+      "Instances": [
+        {
+          "LaunchTime": "2013-08-19T20:53:25.584Z",
+          "InstanceId": "i-1234567890abcdef0",
+          "PublicIpAddress": "55.66.77.88",
+          "PrivateIpAddress": "11.22.33.44",
+          "PrivateDnsName": "ip-10-251-50-12.ec2.internal",
+          "PublicDnsName": "ec2-203-0-113-25.compute-1.amazonaws.com",
+          "Tags": [
+            {
+              "Value": "$asg_name",
+              "Key": "aws:autoscaling:groupName"
+            }
+          ]
+        },
+        {
+          "LaunchTime": "2013-08-19T20:53:25.584Z",
+          "InstanceId": "i-1234567890abcdef1",
+          "PublicIpAddress": "55.66.77.881",
+          "PrivateIpAddress": "11.22.33.441",
+          "PrivateDnsName": "ip-10-251-50-121.ec2.internal",
+          "PublicDnsName": "ec2-203-0-113-252.compute-1.amazonaws.com",
+          "Tags": [
+            {
+              "Value": "$asg_name",
+              "Key": "aws:autoscaling:groupName"
+            }
+          ]
+        },
+        {
+          "LaunchTime": "2013-08-19T20:53:25.584Z",
+          "InstanceId": "i-1234567890abcdef2",
+          "PublicIpAddress": "55.66.77.882",
+          "PrivateIpAddress": "11.22.33.442",
+          "PrivateDnsName": "ip-10-251-50-121.ec2.internal",
+          "PublicDnsName": "ec2-203-0-113-252.compute-1.amazonaws.com",
+          "Tags": [
+            {
+              "Value": "$asg_name",
+              "Key": "aws:autoscaling:groupName"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+END_HEREDOC
+)
+
+  load_aws_mock "" "$asg" "$instances"
+
+  local out
+  out=$(aws_wrapper_wait_for_instances_in_asg "$asg_name" "us-east-1" "$max_retries" "$sleep_between_retries")
+
+  assert_success
+  assert_equal "$instances" "$out"
+}
+
+@test "aws_wrapper_wait_for_instances_in_asg ASG size 3, only 2 available" {
+  local readonly size=3
+  local readonly asg_name="asg-name"
+  local reaodnly max_retries=1
+  local readonly sleep_between_retries=0
+
+  local readonly asg=$(cat <<END_HEREDOC
+{
+    "AutoScalingGroups": [
+        {
+            "AutoScalingGroupARN": "arn:aws:autoscaling:us-west-2:123456789012:autoScalingGroup:930d940e-891e-4781-a11a-7b0acd480f03:autoScalingGroupName/$asg_name",
+            "DesiredCapacity": $size,
+            "AutoScalingGroupName": "$asg_name",
+            "MinSize": 0,
+            "MaxSize": 10,
+            "LaunchConfigurationName": "my-launch-config",
+            "CreatedTime": "2013-08-19T20:53:25.584Z",
+            "AvailabilityZones": [
+                "us-west-2c"
+            ]
+        }
+    ]
+}
+END_HEREDOC
+)
+
+  local readonly instances=$(cat <<END_HEREDOC
+{
+  "Reservations": [
+    {
+      "Instances": [
+        {
+          "LaunchTime": "2013-08-19T20:53:25.584Z",
+          "InstanceId": "i-1234567890abcdef0",
+          "PublicIpAddress": "55.66.77.88",
+          "PrivateIpAddress": "11.22.33.44",
+          "PrivateDnsName": "ip-10-251-50-12.ec2.internal",
+          "PublicDnsName": "ec2-203-0-113-25.compute-1.amazonaws.com",
+          "Tags": [
+            {
+              "Value": "$asg_name",
+              "Key": "aws:autoscaling:groupName"
+            }
+          ]
+        },
+        {
+          "LaunchTime": "2013-08-19T20:53:25.584Z",
+          "InstanceId": "i-1234567890abcdef1",
+          "PublicIpAddress": "55.66.77.881",
+          "PrivateIpAddress": "11.22.33.441",
+          "PrivateDnsName": "ip-10-251-50-121.ec2.internal",
+          "PublicDnsName": "ec2-203-0-113-252.compute-1.amazonaws.com",
+          "Tags": [
+            {
+              "Value": "$asg_name",
+              "Key": "aws:autoscaling:groupName"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+END_HEREDOC
+)
+
+  load_aws_mock "" "$asg" "$instances"
+
+  run aws_wrapper_wait_for_instances_in_asg "$asg_name" "us-east-1" "$max_retries" "$sleep_between_retries"
+
+  assert_failure
+}
+
+@test "aws_wrapper_wait_for_instances_in_asg ASG size not available" {
+  local readonly asg_name="asg-name"
+  local reaodnly max_retries=1
+  local readonly sleep_between_retries=0
+
+  local readonly asg=$(cat <<END_HEREDOC
+{
+    "AutoScalingGroups": []
+}
+END_HEREDOC
+)
+
+  local readonly instances=$(cat <<END_HEREDOC
+{
+  "Reservations": [
+    {
+      "Instances": [
+        {
+          "LaunchTime": "2013-08-19T20:53:25.584Z",
+          "InstanceId": "i-1234567890abcdef0",
+          "PublicIpAddress": "55.66.77.88",
+          "PrivateIpAddress": "11.22.33.44",
+          "PrivateDnsName": "ip-10-251-50-12.ec2.internal",
+          "PublicDnsName": "ec2-203-0-113-25.compute-1.amazonaws.com",
+          "Tags": [
+            {
+              "Value": "$asg_name",
+              "Key": "aws:autoscaling:groupName"
+            }
+          ]
+        },
+        {
+          "LaunchTime": "2013-08-19T20:53:25.584Z",
+          "InstanceId": "i-1234567890abcdef1",
+          "PublicIpAddress": "55.66.77.881",
+          "PrivateIpAddress": "11.22.33.441",
+          "PrivateDnsName": "ip-10-251-50-121.ec2.internal",
+          "PublicDnsName": "ec2-203-0-113-252.compute-1.amazonaws.com",
+          "Tags": [
+            {
+              "Value": "$asg_name",
+              "Key": "aws:autoscaling:groupName"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+END_HEREDOC
+)
+
+  load_aws_mock "" "$asg" "$instances"
+
+  run aws_wrapper_wait_for_instances_in_asg "$asg_name" "us-east-1" "$max_retries" "$sleep_between_retries"
+
+  assert_failure
+}
+
+@test "aws_wrapper_get_ips_in_asg empty ASG" {
+  local readonly asg_name="foo"
+  local readonly size=0
+  local readonly max_retries=1
+  local readonly sleep_between_retries=0
+
+  local readonly asg=$(cat <<END_HEREDOC
+{
+    "AutoScalingGroups": [
+        {
+            "AutoScalingGroupARN": "arn:aws:autoscaling:us-west-2:123456789012:autoScalingGroup:930d940e-891e-4781-a11a-7b0acd480f03:autoScalingGroupName/$asg_name",
+            "DesiredCapacity": $size,
+            "AutoScalingGroupName": "$asg_name",
+            "MinSize": 0,
+            "MaxSize": 10,
+            "LaunchConfigurationName": "my-launch-config",
+            "CreatedTime": "2013-08-19T20:53:25.584Z",
+            "AvailabilityZones": [
+                "us-west-2c"
+            ]
+        }
+    ]
+}
+END_HEREDOC
+)
+
+  local readonly instances=$(cat <<END_HEREDOC
+{
+  "Reservations": []
+}
+END_HEREDOC
+)
+
+  load_aws_mock "" "$asg" "$instances"
+
+  local out
+  out=($(aws_wrapper_get_ips_in_asg "$asg_name" "us-east-1" "true" "$max_retries" "$sleep_between_retries"))
+
+  local readonly expected=()
+
+  assert_success
+  assert_equal "$expected" "$out"
+}
+
+@test "aws_wrapper_get_ips_in_asg ASG size 1, public IPs" {
+  local readonly asg_name="foo"
+  local readonly size=1
+  local readonly max_retries=1
+  local readonly sleep_between_retries=0
+
+  local readonly asg=$(cat <<END_HEREDOC
+{
+    "AutoScalingGroups": [
+        {
+            "AutoScalingGroupARN": "arn:aws:autoscaling:us-west-2:123456789012:autoScalingGroup:930d940e-891e-4781-a11a-7b0acd480f03:autoScalingGroupName/$asg_name",
+            "DesiredCapacity": $size,
+            "AutoScalingGroupName": "$asg_name",
+            "MinSize": 0,
+            "MaxSize": 10,
+            "LaunchConfigurationName": "my-launch-config",
+            "CreatedTime": "2013-08-19T20:53:25.584Z",
+            "AvailabilityZones": [
+                "us-west-2c"
+            ]
+        }
+    ]
+}
+END_HEREDOC
+)
+
+  local readonly instances=$(cat <<END_HEREDOC
+{
+  "Reservations": [
+    {
+      "Instances": [
+        {
+          "LaunchTime": "2013-08-19T20:53:25.584Z",
+          "InstanceId": "i-1234567890abcdef0",
+          "PublicIpAddress": "55.66.77.88",
+          "PrivateIpAddress": "11.22.33.44",
+          "PrivateDnsName": "ip-10-251-50-12.ec2.internal",
+          "PublicDnsName": "ec2-203-0-113-25.compute-1.amazonaws.com",
+          "Tags": [
+            {
+              "Value": "$asg_name",
+              "Key": "aws:autoscaling:groupName"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+END_HEREDOC
+)
+
+  load_aws_mock "" "$asg" "$instances"
+
+  local out
+  out=($(aws_wrapper_get_ips_in_asg "$asg_name" "us-east-1" "true" "$max_retries" "$sleep_between_retries"))
+
+  local readonly expected=("55.66.77.88")
+
+  assert_success
+  assert_equal "$expected" "$out"
+}
+
+@test "aws_wrapper_get_ips_in_asg ASG size 3, public IPs" {
+  local readonly asg_name="foo"
+  local readonly size=3
+  local readonly max_retries=1
+  local readonly sleep_between_retries=0
+
+  local readonly asg=$(cat <<END_HEREDOC
+{
+    "AutoScalingGroups": [
+        {
+            "AutoScalingGroupARN": "arn:aws:autoscaling:us-west-2:123456789012:autoScalingGroup:930d940e-891e-4781-a11a-7b0acd480f03:autoScalingGroupName/$asg_name",
+            "DesiredCapacity": $size,
+            "AutoScalingGroupName": "$asg_name",
+            "MinSize": 0,
+            "MaxSize": 10,
+            "LaunchConfigurationName": "my-launch-config",
+            "CreatedTime": "2013-08-19T20:53:25.584Z",
+            "AvailabilityZones": [
+                "us-west-2c"
+            ]
+        }
+    ]
+}
+END_HEREDOC
+)
+
+  local readonly instances=$(cat <<END_HEREDOC
+{
+  "Reservations": [
+    {
+      "Instances": [
+        {
+          "LaunchTime": "2013-08-19T20:53:25.584Z",
+          "InstanceId": "i-1234567890abcdef0",
+          "PublicIpAddress": "55.66.77.88",
+          "PrivateIpAddress": "11.22.33.44",
+          "PrivateDnsName": "ip-10-251-50-12.ec2.internal",
+          "PublicDnsName": "ec2-203-0-113-25.compute-1.amazonaws.com",
+          "Tags": [
+            {
+              "Value": "$asg_name",
+              "Key": "aws:autoscaling:groupName"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Instances": [
+        {
+          "LaunchTime": "2013-08-19T20:53:25.584Z",
+          "InstanceId": "i-1234567890abcdef1",
+          "PublicIpAddress": "55.66.77.881",
+          "PrivateIpAddress": "11.22.33.441",
+          "PrivateDnsName": "ip-10-251-50-121.ec2.internal",
+          "PublicDnsName": "ec2-203-0-113-252.compute-1.amazonaws.com",
+          "Tags": [
+            {
+              "Value": "$asg_name",
+              "Key": "aws:autoscaling:groupName"
+            }
+          ]
+        },
+        {
+          "LaunchTime": "2013-08-19T20:53:25.584Z",
+          "InstanceId": "i-1234567890abcdef2",
+          "PublicIpAddress": "55.66.77.882",
+          "PrivateIpAddress": "11.22.33.442",
+          "PrivateDnsName": "ip-10-251-50-122.ec2.internal",
+          "PublicDnsName": "ec2-203-0-113-253.compute-1.amazonaws.com",
+          "Tags": [
+            {
+              "Value": "$asg_name",
+              "Key": "aws:autoscaling:groupName"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+END_HEREDOC
+)
+
+  load_aws_mock "" "$asg" "$instances"
+
+  local out
+  out=($(aws_wrapper_get_ips_in_asg "$asg_name" "us-east-1" "true" "$max_retries" "$sleep_between_retries"))
+
+  local readonly expected=("55.66.77.88" "55.66.77.881" "55.66.77.882")
+
+  assert_success
+  assert_equal "$expected" "$out"
+}
+
+@test "aws_wrapper_get_ips_in_asg ASG size 3, private IPs" {
+  local readonly asg_name="foo"
+  local readonly size=3
+  local readonly max_retries=1
+  local readonly sleep_between_retries=0
+
+  local readonly asg=$(cat <<END_HEREDOC
+{
+    "AutoScalingGroups": [
+        {
+            "AutoScalingGroupARN": "arn:aws:autoscaling:us-west-2:123456789012:autoScalingGroup:930d940e-891e-4781-a11a-7b0acd480f03:autoScalingGroupName/$asg_name",
+            "DesiredCapacity": $size,
+            "AutoScalingGroupName": "$asg_name",
+            "MinSize": 0,
+            "MaxSize": 10,
+            "LaunchConfigurationName": "my-launch-config",
+            "CreatedTime": "2013-08-19T20:53:25.584Z",
+            "AvailabilityZones": [
+                "us-west-2c"
+            ]
+        }
+    ]
+}
+END_HEREDOC
+)
+
+  local readonly instances=$(cat <<END_HEREDOC
+{
+  "Reservations": [
+    {
+      "Instances": [
+        {
+          "LaunchTime": "2013-08-19T20:53:25.584Z",
+          "InstanceId": "i-1234567890abcdef0",
+          "PublicIpAddress": "55.66.77.88",
+          "PrivateIpAddress": "11.22.33.44",
+          "PrivateDnsName": "ip-10-251-50-12.ec2.internal",
+          "PublicDnsName": "ec2-203-0-113-25.compute-1.amazonaws.com",
+          "Tags": [
+            {
+              "Value": "$asg_name",
+              "Key": "aws:autoscaling:groupName"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Instances": [
+        {
+          "LaunchTime": "2013-08-19T20:53:25.584Z",
+          "InstanceId": "i-1234567890abcdef1",
+          "PublicIpAddress": "55.66.77.881",
+          "PrivateIpAddress": "11.22.33.441",
+          "PrivateDnsName": "ip-10-251-50-121.ec2.internal",
+          "PublicDnsName": "ec2-203-0-113-252.compute-1.amazonaws.com",
+          "Tags": [
+            {
+              "Value": "$asg_name",
+              "Key": "aws:autoscaling:groupName"
+            }
+          ]
+        },
+        {
+          "LaunchTime": "2013-08-19T20:53:25.584Z",
+          "InstanceId": "i-1234567890abcdef2",
+          "PublicIpAddress": "55.66.77.882",
+          "PrivateIpAddress": "11.22.33.442",
+          "PrivateDnsName": "ip-10-251-50-122.ec2.internal",
+          "PublicDnsName": "ec2-203-0-113-253.compute-1.amazonaws.com",
+          "Tags": [
+            {
+              "Value": "$asg_name",
+              "Key": "aws:autoscaling:groupName"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+END_HEREDOC
+)
+
+  load_aws_mock "" "$asg" "$instances"
+
+  local out
+  out=($(aws_wrapper_get_ips_in_asg "$asg_name" "us-east-1" "false" "$max_retries" "$sleep_between_retries"))
+
+  local readonly expected=("11.22.33.44" "11.22.33.441" "11.22.33.442")
+
+  assert_success
+  assert_equal "$expected" "$out"
+}
+
+@test "aws_wrapper_get_hostnames_in_asg empty ASG" {
+  local readonly asg_name="foo"
+  local readonly size=0
+  local readonly max_retries=1
+  local readonly sleep_between_retries=0
+
+  local readonly asg=$(cat <<END_HEREDOC
+{
+    "AutoScalingGroups": [
+        {
+            "AutoScalingGroupARN": "arn:aws:autoscaling:us-west-2:123456789012:autoScalingGroup:930d940e-891e-4781-a11a-7b0acd480f03:autoScalingGroupName/$asg_name",
+            "DesiredCapacity": $size,
+            "AutoScalingGroupName": "$asg_name",
+            "MinSize": 0,
+            "MaxSize": 10,
+            "LaunchConfigurationName": "my-launch-config",
+            "CreatedTime": "2013-08-19T20:53:25.584Z",
+            "AvailabilityZones": [
+                "us-west-2c"
+            ]
+        }
+    ]
+}
+END_HEREDOC
+)
+
+  local readonly instances=$(cat <<END_HEREDOC
+{
+  "Reservations": []
+}
+END_HEREDOC
+)
+
+  load_aws_mock "" "$asg" "$instances"
+
+  local out
+  out=($(aws_wrapper_get_hostnames_in_asg "$asg_name" "us-east-1" "true" "$max_retries" "$sleep_between_retries"))
+
+  local readonly expected=()
+
+  assert_success
+  assert_equal "$expected" "$out"
+}
+
+@test "aws_wrapper_get_hostnames_in_asg ASG size 1, public IPs" {
+  local readonly asg_name="foo"
+  local readonly size=1
+  local readonly max_retries=1
+  local readonly sleep_between_retries=0
+
+  local readonly asg=$(cat <<END_HEREDOC
+{
+    "AutoScalingGroups": [
+        {
+            "AutoScalingGroupARN": "arn:aws:autoscaling:us-west-2:123456789012:autoScalingGroup:930d940e-891e-4781-a11a-7b0acd480f03:autoScalingGroupName/$asg_name",
+            "DesiredCapacity": $size,
+            "AutoScalingGroupName": "$asg_name",
+            "MinSize": 0,
+            "MaxSize": 10,
+            "LaunchConfigurationName": "my-launch-config",
+            "CreatedTime": "2013-08-19T20:53:25.584Z",
+            "AvailabilityZones": [
+                "us-west-2c"
+            ]
+        }
+    ]
+}
+END_HEREDOC
+)
+
+  local readonly instances=$(cat <<END_HEREDOC
+{
+  "Reservations": [
+    {
+      "Instances": [
+        {
+          "LaunchTime": "2013-08-19T20:53:25.584Z",
+          "InstanceId": "i-1234567890abcdef0",
+          "PublicIpAddress": "55.66.77.88",
+          "PrivateIpAddress": "11.22.33.44",
+          "PrivateDnsName": "ip-10-251-50-12.ec2.internal",
+          "PublicDnsName": "ec2-203-0-113-25.compute-1.amazonaws.com",
+          "Tags": [
+            {
+              "Value": "$asg_name",
+              "Key": "aws:autoscaling:groupName"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+END_HEREDOC
+)
+
+  load_aws_mock "" "$asg" "$instances"
+
+  local out
+  out=($(aws_wrapper_get_hostnames_in_asg "$asg_name" "us-east-1" "true" "$max_retries" "$sleep_between_retries"))
+
+  local readonly expected=("ec2-203-0-113-25.compute-1.amazonaws.com")
+
+  assert_success
+  assert_equal "$expected" "$out"
+}
+
+@test "aws_wrapper_get_hostnames_in_asg ASG size 3, public IPs" {
+  local readonly asg_name="foo"
+  local readonly size=3
+  local readonly max_retries=1
+  local readonly sleep_between_retries=0
+
+  local readonly asg=$(cat <<END_HEREDOC
+{
+    "AutoScalingGroups": [
+        {
+            "AutoScalingGroupARN": "arn:aws:autoscaling:us-west-2:123456789012:autoScalingGroup:930d940e-891e-4781-a11a-7b0acd480f03:autoScalingGroupName/$asg_name",
+            "DesiredCapacity": $size,
+            "AutoScalingGroupName": "$asg_name",
+            "MinSize": 0,
+            "MaxSize": 10,
+            "LaunchConfigurationName": "my-launch-config",
+            "CreatedTime": "2013-08-19T20:53:25.584Z",
+            "AvailabilityZones": [
+                "us-west-2c"
+            ]
+        }
+    ]
+}
+END_HEREDOC
+)
+
+  local readonly instances=$(cat <<END_HEREDOC
+{
+  "Reservations": [
+    {
+      "Instances": [
+        {
+          "LaunchTime": "2013-08-19T20:53:25.584Z",
+          "InstanceId": "i-1234567890abcdef0",
+          "PublicIpAddress": "55.66.77.88",
+          "PrivateIpAddress": "11.22.33.44",
+          "PrivateDnsName": "ip-10-251-50-12.ec2.internal",
+          "PublicDnsName": "ec2-203-0-113-25.compute-1.amazonaws.com",
+          "Tags": [
+            {
+              "Value": "$asg_name",
+              "Key": "aws:autoscaling:groupName"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Instances": [
+        {
+          "LaunchTime": "2013-08-19T20:53:25.584Z",
+          "InstanceId": "i-1234567890abcdef1",
+          "PublicIpAddress": "55.66.77.881",
+          "PrivateIpAddress": "11.22.33.441",
+          "PrivateDnsName": "ip-10-251-50-121.ec2.internal",
+          "PublicDnsName": "ec2-203-0-113-252.compute-1.amazonaws.com",
+          "Tags": [
+            {
+              "Value": "$asg_name",
+              "Key": "aws:autoscaling:groupName"
+            }
+          ]
+        },
+        {
+          "LaunchTime": "2013-08-19T20:53:25.584Z",
+          "InstanceId": "i-1234567890abcdef2",
+          "PublicIpAddress": "55.66.77.882",
+          "PrivateIpAddress": "11.22.33.442",
+          "PrivateDnsName": "ip-10-251-50-122.ec2.internal",
+          "PublicDnsName": "ec2-203-0-113-253.compute-1.amazonaws.com",
+          "Tags": [
+            {
+              "Value": "$asg_name",
+              "Key": "aws:autoscaling:groupName"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+END_HEREDOC
+)
+
+  load_aws_mock "" "$asg" "$instances"
+
+  local out
+  out=($(aws_wrapper_get_hostnames_in_asg "$asg_name" "us-east-1" "true" "$max_retries" "$sleep_between_retries"))
+
+  local readonly expected=("ec2-203-0-113-25.compute-1.amazonaws.com" "ec2-203-0-113-252.compute-1.amazonaws.com" "ec2-203-0-113-253.compute-1.amazonaws.com")
+
+  assert_success
+  assert_equal "$expected" "$out"
+}
+
+@test "aws_wrapper_get_hostnames_in_asg ASG size 3, private IPs" {
+  local readonly asg_name="foo"
+  local readonly size=3
+  local readonly max_retries=1
+  local readonly sleep_between_retries=0
+
+  local readonly asg=$(cat <<END_HEREDOC
+{
+    "AutoScalingGroups": [
+        {
+            "AutoScalingGroupARN": "arn:aws:autoscaling:us-west-2:123456789012:autoScalingGroup:930d940e-891e-4781-a11a-7b0acd480f03:autoScalingGroupName/$asg_name",
+            "DesiredCapacity": $size,
+            "AutoScalingGroupName": "$asg_name",
+            "MinSize": 0,
+            "MaxSize": 10,
+            "LaunchConfigurationName": "my-launch-config",
+            "CreatedTime": "2013-08-19T20:53:25.584Z",
+            "AvailabilityZones": [
+                "us-west-2c"
+            ]
+        }
+    ]
+}
+END_HEREDOC
+)
+
+  local readonly instances=$(cat <<END_HEREDOC
+{
+  "Reservations": [
+    {
+      "Instances": [
+        {
+          "LaunchTime": "2013-08-19T20:53:25.584Z",
+          "InstanceId": "i-1234567890abcdef0",
+          "PublicIpAddress": "55.66.77.88",
+          "PrivateIpAddress": "11.22.33.44",
+          "PrivateDnsName": "ip-10-251-50-12.ec2.internal",
+          "PublicDnsName": "ec2-203-0-113-25.compute-1.amazonaws.com",
+          "Tags": [
+            {
+              "Value": "$asg_name",
+              "Key": "aws:autoscaling:groupName"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Instances": [
+        {
+          "LaunchTime": "2013-08-19T20:53:25.584Z",
+          "InstanceId": "i-1234567890abcdef1",
+          "PublicIpAddress": "55.66.77.881",
+          "PrivateIpAddress": "11.22.33.441",
+          "PrivateDnsName": "ip-10-251-50-121.ec2.internal",
+          "PublicDnsName": "ec2-203-0-113-252.compute-1.amazonaws.com",
+          "Tags": [
+            {
+              "Value": "$asg_name",
+              "Key": "aws:autoscaling:groupName"
+            }
+          ]
+        },
+        {
+          "LaunchTime": "2013-08-19T20:53:25.584Z",
+          "InstanceId": "i-1234567890abcdef2",
+          "PublicIpAddress": "55.66.77.882",
+          "PrivateIpAddress": "11.22.33.442",
+          "PrivateDnsName": "ip-10-251-50-122.ec2.internal",
+          "PublicDnsName": "ec2-203-0-113-253.compute-1.amazonaws.com",
+          "Tags": [
+            {
+              "Value": "$asg_name",
+              "Key": "aws:autoscaling:groupName"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+END_HEREDOC
+)
+
+  load_aws_mock "" "$asg" "$instances"
+
+  local out
+  out=($(aws_wrapper_get_hostnames_in_asg "$asg_name" "us-east-1" "false" "$max_retries" "$sleep_between_retries"))
+
+  local readonly expected=("ip-10-251-50-12.ec2.internal" "ip-10-251-50-121.ec2.internal" "ip-10-251-50-122.ec2.internal")
+
+  assert_success
+  assert_equal "$expected" "$out"
+}
+
+@test "aws_wrapper_get_hostname public" {
+  load_aws_mock "" "" ""
+
+  local out
+  out=$(aws_wrapper_get_hostname "true")
+
+  assert_success
+  assert_equal "ec2-203-0-113-25.compute-1.amazonaws.com" "$out"
+}
+
+@test "aws_wrapper_get_hostname private" {
+  load_aws_mock "" "" ""
+
+  local out
+  out=$(aws_wrapper_get_hostname "false")
+
+  assert_success
+  assert_equal "ip-10-251-50-12.ec2.internal" "$out"
+}

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -7,3 +7,12 @@ services:
       - ../:/usr/src/bash-commons
     working_dir: /usr/src/bash-commons
     command: bats test
+
+    # Necessary so we can run a mock EC2 metadata service on port 80 on a special IP
+    privileged: true
+
+    ports:
+      # For moto
+      - "5000:5000"
+      # For ec2-metadata-mock
+      - "8111:8111"

--- a/test/ec2-metadata-mock/ec2-metadata-mock.py
+++ b/test/ec2-metadata-mock/ec2-metadata-mock.py
@@ -1,0 +1,41 @@
+# A dirt-simple mock for the EC2 metadata service, built on top of Python and Flask. It allows you to set a mock value
+# for /latest/meta-data/<path> by setting the env var meta_data_<path> and the mock value for /latest/dynamic/<path>
+# by setting the env var dynamic_data_<path>. Note that dashes (-) in <path> should be replaced with underscores (_)
+# and slashes (/) in the path should be replaced with double underscores (__). e.g.:
+#
+# export meta_data_instance_id=i-1234567890abcdef0
+# export meta_data_placement__availability_zone=us-west-2b
+#
+
+import os
+import logging
+from flask import Flask
+
+app = Flask(__name__)
+
+META_DATA_ENV_VAR_PREFIX = 'meta_data'
+DYNAMIC_DATA_ENV_VAR_PREFIX = 'dynamic_data'
+
+@app.route("/latest/meta-data/<path:path>")
+def meta_data(path):
+    return lookup_path(path, META_DATA_ENV_VAR_PREFIX)
+
+@app.route("/latest/dynamic/<path:path>")
+def dynamic_data(path):
+    return lookup_path(path, DYNAMIC_DATA_ENV_VAR_PREFIX)
+
+def lookup_path(path, prefix):
+    env_var_name = path_to_env_var(path, prefix)
+    logging.info('Looking for env var %s' % env_var_name)
+    if env_var_name in os.environ:
+        return os.environ[env_var_name]
+    else:
+        return 'Value for environment variable %s not found' % env_var_name, 404
+
+def path_to_env_var(path, prefix):
+    return '%s_%s' % (prefix, strip_suffix(path, '/').replace('/', '__').replace('-', '_'))
+
+def strip_suffix(str, suffix):
+    if str.endswith(suffix):
+        return str[:-len(suffix)]
+    return str

--- a/test/test-helper.bash
+++ b/test/test-helper.bash
@@ -1,3 +1,4 @@
+#!/bin/bash
 # This is a series of helper functions copy/pasted from many other repos that use BATS for testing. The code isn't
 # pretty, and doesn't follow many of our conventions, but it's useful.
 
@@ -47,6 +48,29 @@ assert_equal_regex() {
   fi
 }
 
+assert_equal_json() {
+  local readonly expected="$1"
+  local readonly actual="$2"
+
+  local expected_json
+  expected_json=$(echo "$expected" | jq -r '.')
+
+  local actual_json
+  actual_json=$(echo "$actual" | jq -r '.')
+
+  if [[ "$expected_json" != "$actual_json" ]]; then
+    { echo "expected: $expected_json"
+      echo "actual:   $actual_json"
+    } | flunk
+  fi
+}
+
+assert_greater_than() {
+  if [ ! "$1" -gt "$2" ]; then
+    echo "expected $1 to be greater than $2" | flunk
+  fi
+}
+
 assert_output() {
   local expected
   if [ $# -eq 0 ]; then expected="$(cat -)"
@@ -61,6 +85,14 @@ assert_output_regex() {
   else expected="$1"
   fi
   assert_equal_regex "$expected" "$output"
+}
+
+assert_output_json() {
+  local expected
+  if [ $# -eq 0 ]; then expected="$(cat -)"
+  else expected="$1"
+  fi
+  assert_equal_json "$expected" "$output"
 }
 
 assert_line() {


### PR DESCRIPTION
In #1, I had test for everything but the two AWS bash scripts, as those are tricky to unit test. I started to use those scripts in another project, and, not too surprisingly, hit a bug.

So, I bit the bullet, and figured out how to unit test these suckers using `moto`, a mock EC2 metadata server, and some other hacks. It was a PITA, that included some yak shaving around bats, but the upside is I actually found and fixed several bugs, so I guess it was worth the effort.