### PR TITLE
Add function to get instance with specific tags

### DIFF
--- a/modules/bash-commons/src/aws-wrapper.sh
+++ b/modules/bash-commons/src/aws-wrapper.sh
@@ -179,7 +179,6 @@ function aws_wrapper_get_ips_with_tag {
 
   local instances
   instances=$(aws_get_instances_with_tag "$tag_key" "$tag_value" "$aws_region")
-  assert_not_empty_or_null "$instances" "Get info about Instances with tag $tag_key set to $tag_value"
 
   local readonly ip_param=$([[ "$use_public_ips" == "true" ]] && echo "PublicIpAddress" || echo "PrivateIpAddress")
   echo "$instances" | jq -r ".Reservations[].Instances[].$ip_param"

--- a/modules/bash-commons/src/aws-wrapper.sh
+++ b/modules/bash-commons/src/aws-wrapper.sh
@@ -169,6 +169,22 @@ function aws_wrapper_get_ips_in_asg {
   echo "$instances" | jq -r ".Reservations[].Instances[].$ip_param"
 }
 
+# Return a space-separated list of IPs belonging to instances with specific tag values.
+# If use_public_ips is "true", these will be the public IPs; otherwise, these will be the private IPs.
+function aws_wrapper_get_ips_with_tag {
+  local readonly tag_key="$1"
+  local readonly tag_value="$2"
+  local readonly aws_region="$3"
+  local readonly use_public_ips="$4"
+
+  local instances
+  instances=$(aws_get_instances_with_tag "$tag_key" "$tag_value" "$aws_region")
+  assert_not_empty_or_null "$instances" "Get info about Instances with tag $tag_key set to $tag_value"
+
+  local readonly ip_param=$([[ "$use_public_ips" == "true" ]] && echo "PublicIpAddress" || echo "PrivateIpAddress")
+  echo "$instances" | jq -r ".Reservations[].Instances[].$ip_param"
+}
+
 # Return a space-separated list of hostnames in the given ASG. If use_public_hostnames is "true", these will be the
 # public hostnames; otherwise, these will be the private hostnames.
 function aws_wrapper_get_hostnames_in_asg {

--- a/modules/bash-commons/src/aws.sh
+++ b/modules/bash-commons/src/aws.sh
@@ -62,6 +62,17 @@ function aws_get_instance_tags {
     --filters "Name=resource-type,Values=instance" "Name=resource-id,Values=$instance_id"
 }
 
+# Get the instances with a given tag and in a specific region. Returns JSON from the AWS CLI's describe-instances command.
+function aws_get_instances_with_tag {
+  local readonly tag_key="$1"
+  local readonly tag_value="$2"
+  local readonly instance_region="$3"
+
+  aws ec2 describe-instances \
+    --region "$instance_region" \
+    --filters "Name=tag:$tag_key,Values=$tag_value"
+}
+
 # Describe the given ASG in the given region. Returns JSON from the AWS CLI's describe-auto-scaling-groups command.
 function aws_describe_asg {
   local readonly asg_name="$1"

--- a/test/aws-cli.bats
+++ b/test/aws-cli.bats
@@ -122,3 +122,31 @@ END_HEREDOC
   num_instances=$(echo "$output" | jq -r '.Reservations | length')
   assert_greater_than "$num_instances" 0
 }
+
+@test "aws_get_instances_with_tag empty" {
+  run aws_get_instances_with_tag "Name" "Value" "us-east-1"
+  assert_success
+
+  local readonly expected=$(cat <<END_HEREDOC
+{
+  "Reservations": []
+}
+END_HEREDOC
+)
+
+  assert_output_json "$expected"
+}
+
+@test "aws_get_instances_with_tag non-empty" {
+  local -r tag_key="Name"
+  local -r tag_value="Value"
+  local -r region="us-east-1"
+
+  create_mock_instance_with_tags "$tag_key" "$tag_value"
+  run aws_get_instances_with_tag "$tag_key" "$tag_value" "$region"
+  assert_success
+
+  local num_instances
+  num_instances=$(echo "$output" | jq -r '.Reservations | length')
+  assert_greater_than "$num_instances" 0
+}


### PR DESCRIPTION
This PR is meant to address a need in https://github.com/gruntwork-io/package-elk/pull/43. Specifically this comment https://github.com/gruntwork-io/package-elk/pull/43#discussion_r213864939 about using tags to retrieve IPs instead of ASG names.

The PR includes the following:
1. A function `aws_get_instances_with_tag` within `aws.sh` that simply returns the json result from the call to the `aws-cli`
2. A function `aws_wrapper_get_ips_with_tag` within `aws-wrapper.sh` that calls the `aws_get_instances_with_tag` function and returns the public or private IPs of the instances 
3. Tests which have not yet been added because I'm still trying to figure out bats