### PR TITLE
Add function to fill out template strings in files

### DIFF
--- a/modules/bash-commons/src/file.sh
+++ b/modules/bash-commons/src/file.sh
@@ -4,6 +4,7 @@
 set -e
 
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/os.sh"
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/string.sh"
 
 # Returns true (0) if the given file exists and is a file and false (1) otherwise
 function file_exists {
@@ -62,4 +63,22 @@ function file_replace_or_append_text {
   else
     file_append_text "$replacement_text" "$file"
   fi
+}
+
+# Replace a specific template string in a file with a value. Provided as an array of TEMPLATE-STRING=VALUE
+function file_fill_template {
+  local -r file="$1"
+  shift 1
+  local -ar auto_fill=("$@")
+
+  if [[ -z "${auto_fill[@]}" ]]; then
+    log_info "No auto-fill params specified."
+    return
+  fi
+
+  for param in "${auto_fill[@]}"; do
+    local -r name="$(string_strip_suffix "$param" "=*")"
+    local -r value="$(string_strip_prefix "$param" "*=")"
+    file_replace_text "$name" "$value" "$file"
+  done
 }

--- a/modules/bash-commons/src/file.sh
+++ b/modules/bash-commons/src/file.sh
@@ -76,9 +76,11 @@ function file_fill_template {
     return
   fi
 
+  local name
+  local value
   for param in "${auto_fill[@]}"; do
-    local -r name="$(string_strip_suffix "$param" "=*")"
-    local -r value="$(string_strip_prefix "$param" "*=")"
+    name="$(string_strip_suffix "$param" "=*")"
+    value="$(string_strip_prefix "$param" "*=")"
     file_replace_text "$name" "$value" "$file"
   done
 }

--- a/test/file.bats
+++ b/test/file.bats
@@ -238,3 +238,22 @@ load "test-helper"
 
   rm -f "$tmp_file"
 }
+
+@test "file_fill_template non empty file, replace multiple" {
+  local -r tmp_file=$(mktemp)
+  local -a auto_fill=("<__PLACEHOLDER__>=hello")
+  auto_fill+=("<__PLACEHOLDER2__>=foo")
+
+  local -r file_contents=$(echo -e "abc\n<__PLACEHOLDER__> world\n<__PLACEHOLDER2__> baz")
+
+  echo "$file_contents" > "$tmp_file"
+
+  run file_fill_template "$tmp_file" "${auto_fill[@]}"
+  assert_success
+
+  local -r actual=$(cat "$tmp_file")
+  local -r expected=$(echo -e "abc\nhello world\nfoo baz")
+  assert_equal "$expected" "$actual"
+
+  rm -f "$tmp_file"
+}

--- a/test/file.bats
+++ b/test/file.bats
@@ -204,3 +204,37 @@ load "test-helper"
 
   rm -f "$tmp_file"
 }
+
+@test "file_fill_template non empty file, nothing to replace" {
+  local -r tmp_file=$(mktemp)
+  local -ar auto_fill=("<__PLACEHOLDER__>=hello")
+  local -r file_contents=$(echo -e "abc\nhey world\nbaz")
+
+  echo "$file_contents" > "$tmp_file"
+
+  run file_fill_template "$tmp_file" "${auto_fill[@]}"
+  assert_success
+
+  local -r actual=$(cat "$tmp_file")
+  local -r expected=$file_contents
+  assert_equal "$expected" "$actual"
+
+  rm -f "$tmp_file"
+}
+
+@test "file_fill_template non empty file, replace text" {
+  local -r tmp_file=$(mktemp)
+  local -ar auto_fill=("<__PLACEHOLDER__>=hello")
+  local -r file_contents=$(echo -e "abc\n<__PLACEHOLDER__> world\nbaz")
+
+  echo "$file_contents" > "$tmp_file"
+
+  run file_fill_template "$tmp_file" "${auto_fill[@]}"
+  assert_success
+
+  local -r actual=$(cat "$tmp_file")
+  local -r expected=$(echo -e "abc\nhello world\nbaz")
+  assert_equal "$expected" "$actual"
+
+  rm -f "$tmp_file"
+}


### PR DESCRIPTION
This PR implements a common need we encounter in our `run-*` modules to fill out template strings in configuration files with a specified value.