### PR TITLE
Minor fix for bootstrap compat

### DIFF
--- a/modules/bash-commons/src/array.sh
+++ b/modules/bash-commons/src/array.sh
@@ -20,11 +20,11 @@ function array_contains {
 #
 # Examples:
 #
-# array_split "a,b,c" ","
+# array_split "," "a,b,c"
 #   Returns: ("a" "b" "c")
 #
 # Hint:
-# When calling this function, use the following construction: ary=( $(array_split "a,b,c" ",") )
+# When calling this function, use the following construction: ary=( $(array_split "," "a,b,c") )
 #
 # Sources:
 # - https://stackoverflow.com/a/15988793/2308858

--- a/modules/bash-commons/src/assert.sh
+++ b/modules/bash-commons/src/assert.sh
@@ -89,7 +89,7 @@ function assert_exactly_one_of {
   local -a arg_names=()
 
   # Determine how many arg_vals are non-empty
-  for (( i=0; i<$((num_args+1)); i+=2 )); do
+  for (( i=0; i<$((num_args)); i+=2 )); do
     arg_names+=("${args[i]}")
     if [[ ! -z "${args[i+1]}" ]]; then
       num_non_empty=$((num_non_empty+1))


### PR DESCRIPTION
Found a minor issue when running with bootstrap.sh. The iterator was iterating one time too many.

Also fixes the example for array_split which had the args reversed.