### PR TITLE
Fix CircleCI Contexts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,6 @@ jobs:
     steps:
       - checkout
       - run: docker-compose up shellcheck
-
   integration_test:
     docker:
       - image: 087285199408.dkr.ecr.us-east-1.amazonaws.com/circle-ci-test-image-base:go1.14
@@ -24,7 +23,6 @@ jobs:
           path: /tmp/logs
       - store_test_results:
           path: /tmp/logs
-
   bats_ubuntu1604:
     # We need to run Docker Compose with privileged settings, which isn't supported by CircleCI's Docker executor, so
     # we have to use the machine executor instead.
@@ -32,7 +30,6 @@ jobs:
     steps:
       - checkout
       - run: docker-compose up bats_ubuntu1604
-
   bats_ubuntu1804:
     # We need to run Docker Compose with privileged settings, which isn't supported by CircleCI's Docker executor, so
     # we have to use the machine executor instead.
@@ -40,13 +37,19 @@ jobs:
     steps:
       - checkout
       - run: docker-compose up bats_ubuntu1804
-
 workflows:
   version: 2
   checks:
     jobs:
-      - shellcheck
+      - shellcheck:
+          context:
+            - Gruntwork Admin
       - integration_test:
-          context: Gruntwork Admin
-      - bats_ubuntu1604
-      - bats_ubuntu1804
+          context:
+            - Gruntwork Admin
+      - bats_ubuntu1604:
+          context:
+            - Gruntwork Admin
+      - bats_ubuntu1804:
+          context:
+            - Gruntwork Admin

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,15 +41,9 @@ workflows:
   version: 2
   checks:
     jobs:
-      - shellcheck:
-          context:
-            - Gruntwork Admin
+      - shellcheck
       - integration_test:
           context:
             - Gruntwork Admin
-      - bats_ubuntu1604:
-          context:
-            - Gruntwork Admin
-      - bats_ubuntu1804:
-          context:
-            - Gruntwork Admin
+      - bats_ubuntu1604
+      - bats_ubuntu1804


### PR DESCRIPTION
This pull request was programmatically opened by the multi-repo-updater program. It should be adding the 'Gruntwork Admin' context to any Workflows -> Jobs nodes and should also be leaving the rest of the .circleci/config.yml file alone. 

 This PR was opened so that all our repositories' .circleci/config.yml files can be converted to use the same CircleCI context, which will make rotating secrets much easier in the future.