### PR TITLE
Addition of function to calculate rally point instance in AWS Auto Scaling Groups

### DIFF
--- a/Dockerfile.ubuntu16.04.bats
+++ b/Dockerfile.ubuntu16.04.bats
@@ -12,8 +12,8 @@ RUN apt-get install -y software-properties-common && \
     apt-get install -y bats
 
 # Upgrade pip
-RUN sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 1 && \
-    sudo update-alternatives --config python && \
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1 && \
+    update-alternatives --config python && \
     curl https://bootstrap.pypa.io/pip/3.5/get-pip.py -o /tmp/get-pip.py && \
     python /tmp/get-pip.py && \
     pip install -U pip
@@ -30,3 +30,7 @@ RUN apt-get install -y net-tools iptables
 
 # Copy mock AWS CLI into the PATH
 COPY ./.circleci/aws-local.sh /usr/local/bin/aws
+
+# These have been added to resolve some encoding issues with the tests
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8

--- a/Dockerfile.ubuntu16.04.bats
+++ b/Dockerfile.ubuntu16.04.bats
@@ -3,7 +3,11 @@ MAINTAINER Gruntwork <info@gruntwork.io>
 
 # Install basic dependencies
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
-    apt-get install -y vim python-pip jq sudo curl
+    apt-get install -y vim python-pip jq sudo curl libffi-dev python3-dev && \
+    update-alternatives --install /usr/bin/python python /usr/bin/python3 1 && \
+    update-alternatives --config python && \
+    curl https://bootstrap.pypa.io/pip/3.5/get-pip.py -o /tmp/get-pip.py && \
+    python /tmp/get-pip.py
 
 # Install Bats
 RUN apt-get install -y software-properties-common && \
@@ -12,18 +16,13 @@ RUN apt-get install -y software-properties-common && \
     apt-get install -y bats
 
 # Upgrade pip
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1 && \
-    update-alternatives --config python && \
-    curl https://bootstrap.pypa.io/pip/3.5/get-pip.py -o /tmp/get-pip.py && \
-    python /tmp/get-pip.py && \
-    pip install -U pip
+RUN pip install -U pip
 
 # Install AWS CLI
 RUN pip install awscli --upgrade --user
 
 # Install moto: https://github.com/spulec/moto
-RUN sudo apt install libffi-dev python3-dev -y && \
-    pip install flask moto moto[server] networkx==2.2
+RUN pip install flask moto moto[server] networkx==2.2
 
 # Install tools we'll need to create a mock EC2 metadata server
 RUN apt-get install -y net-tools iptables

--- a/Dockerfile.ubuntu16.04.bats
+++ b/Dockerfile.ubuntu16.04.bats
@@ -30,6 +30,8 @@ RUN apt-get install -y net-tools iptables
 # Copy mock AWS CLI into the PATH
 COPY ./.circleci/aws-local.sh /usr/local/bin/aws
 
-# These have been added to resolve some encoding issues with the tests
+# These have been added to resolve some encoding error issues with the tests. These were introduced during the upgrade to Python 3.6, 
+# which is known to have some sensitivity around locale issues. These variables should correct that, per examples like this SO thread: 
+# https://stackoverflow.com/questions/51026315/how-to-solve-unicodedecodeerror-in-python-3-6/51027262#51027262.
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8

--- a/Dockerfile.ubuntu16.04.bats
+++ b/Dockerfile.ubuntu16.04.bats
@@ -12,13 +12,18 @@ RUN apt-get install -y software-properties-common && \
     apt-get install -y bats
 
 # Upgrade pip
-RUN pip install -U pip
+RUN sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 1 && \
+    sudo update-alternatives --config python && \
+    curl https://bootstrap.pypa.io/pip/3.5/get-pip.py -o /tmp/get-pip.py && \
+    python /tmp/get-pip.py && \
+    pip install -U pip
 
 # Install AWS CLI
 RUN pip install awscli --upgrade --user
 
 # Install moto: https://github.com/spulec/moto
-RUN pip install flask moto moto[server] networkx==2.2
+RUN sudo apt install libffi-dev python3-dev -y && \
+    pip install flask moto moto[server] networkx==2.2
 
 # Install tools we'll need to create a mock EC2 metadata server
 RUN apt-get install -y net-tools iptables

--- a/Dockerfile.ubuntu18.04.bats
+++ b/Dockerfile.ubuntu18.04.bats
@@ -12,9 +12,9 @@ RUN apt-get install -y software-properties-common && \
     apt-get install -y bats
 
 # Install AWS CLI
-RUN sudo apt install python3-distutils python3-apt -y && \
-    sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 1 && \
-    sudo update-alternatives --config python && \
+RUN apt install python3-distutils python3-apt -y && \
+    update-alternatives --install /usr/bin/python python /usr/bin/python3 1 && \
+    update-alternatives --config python && \
     curl https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py && \
     python /tmp/get-pip.py && \
     pip install awscli --upgrade --user
@@ -29,3 +29,7 @@ RUN apt-get install -y net-tools iptables
 
 # Copy mock AWS CLI into the PATH
 COPY ./.circleci/aws-local.sh /usr/local/bin/aws
+
+# These have been added to resolve some encoding error issues with the tests
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8

--- a/Dockerfile.ubuntu18.04.bats
+++ b/Dockerfile.ubuntu18.04.bats
@@ -3,7 +3,7 @@ MAINTAINER Gruntwork <info@gruntwork.io>
 
 # Install basic dependencies
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
-    apt-get install -y vim python-pip jq sudo curl
+    apt-get install -y vim python-pip jq sudo curl libffi-dev python3-dev
 
 # Install Bats
 RUN apt-get install -y software-properties-common && \
@@ -21,8 +21,7 @@ RUN apt install python3-distutils python3-apt -y && \
 
 # Install moto: https://github.com/spulec/moto
 # Lock cfn-lint and pysistent to last known working versions
-RUN sudo apt install libffi-dev python3-dev -y && \
-    pip install flask moto moto[server] cfn-lint==0.35.1 pyrsistent==0.16.0
+RUN pip install flask moto moto[server] cfn-lint==0.35.1 pyrsistent==0.16.0
 
 # Install tools we'll need to create a mock EC2 metadata server
 RUN apt-get install -y net-tools iptables

--- a/Dockerfile.ubuntu18.04.bats
+++ b/Dockerfile.ubuntu18.04.bats
@@ -29,6 +29,8 @@ RUN apt-get install -y net-tools iptables
 # Copy mock AWS CLI into the PATH
 COPY ./.circleci/aws-local.sh /usr/local/bin/aws
 
-# These have been added to resolve some encoding error issues with the tests
+# These have been added to resolve some encoding error issues with the tests. These were introduced during the upgrade to Python 3.6, 
+# which is known to have some sensitivity around locale issues. These variables should correct that, per examples like this SO thread: 
+# https://stackoverflow.com/questions/51026315/how-to-solve-unicodedecodeerror-in-python-3-6/51027262#51027262.
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8

--- a/Dockerfile.ubuntu18.04.bats
+++ b/Dockerfile.ubuntu18.04.bats
@@ -12,11 +12,17 @@ RUN apt-get install -y software-properties-common && \
     apt-get install -y bats
 
 # Install AWS CLI
-RUN pip install awscli --upgrade --user
+RUN sudo apt install python3-distutils python3-apt -y && \
+    sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 1 && \
+    sudo update-alternatives --config python && \
+    curl https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py && \
+    python /tmp/get-pip.py && \
+    pip install awscli --upgrade --user
 
 # Install moto: https://github.com/spulec/moto
 # Lock cfn-lint and pysistent to last known working versions
-RUN pip install flask moto moto[server] cfn-lint==0.35.1 pyrsistent==0.16.0
+RUN sudo apt install libffi-dev python3-dev -y && \
+    pip install flask moto moto[server] cfn-lint==0.35.1 pyrsistent==0.16.0
 
 # Install tools we'll need to create a mock EC2 metadata server
 RUN apt-get install -y net-tools iptables

--- a/modules/bash-commons/src/aws-wrapper.sh
+++ b/modules/bash-commons/src/aws-wrapper.sh
@@ -221,12 +221,14 @@ function aws_wrapper_get_asg_rally_point {
   local -r asg_name="$1"
   local -r aws_region="$2"
   local -r use_public_hostname="$3"
+  local -r retries="${4:-60}"
+  local -r sleep_between_retries="${5:-5}"
 
   log_info "Calculating rally point for ASG $asg_name in $aws_region"
 
   local instances
   log_info "Waiting for all instances to be available..."
-  instances=$(aws_wrapper_wait_for_instances_in_asg $asg_name $aws_region)
+  instances=$(aws_wrapper_wait_for_instances_in_asg $asg_name $aws_region $retries $sleep_between_retries)
   assert_not_empty_or_null "$instances" "Wait for instances in ASG $asg_name in $aws_region"
 
   local rally_point

--- a/modules/bash-commons/src/aws-wrapper.sh
+++ b/modules/bash-commons/src/aws-wrapper.sh
@@ -216,8 +216,7 @@ function aws_wrapper_get_hostname {
   fi
 }
 
-# Calculates a rally point instance in an ASG, which is useful in cases where a piece of code needs to be run only
-# once upon provision of the ASG. Based off of https://github.com/gruntwork-io/terraform-aws-couchbase/blob/master/modules/couchbase-commons/couchbase-rally-point.
+# Calculates a "rally point" instance in an ASG and returns its hostname. This is a deterministic way for the instances in an ASG to all pick the same single instance to perform some action: e.g., this instance could become the leader in a cluster or run some initialization script that should only be run once for the entire ASG. Under the hood, this method picks the instance in the ASG with the earliest launch time; in the case of ties, the instance with the earliest instance ID (lexicographically) is returned. This method assumes jq is installed.
 function aws_wrapper_get_asg_rally_point {
   local -r asg_name="$1"
   local -r aws_region="$2"

--- a/modules/bash-commons/src/aws-wrapper.sh
+++ b/modules/bash-commons/src/aws-wrapper.sh
@@ -215,3 +215,35 @@ function aws_wrapper_get_hostname {
     aws_get_instance_private_hostname
   fi
 }
+
+# Calculates a rally point instance in an ASG, which is useful in cases where a piece of code needs to be run only
+# once upon provision of the ASG. Based off of https://github.com/gruntwork-io/terraform-aws-couchbase/blob/master/modules/couchbase-commons/couchbase-rally-point.
+function aws_wrapper_get_asg_rally_point {
+  local -r asg_name="$1"
+  local -r aws_region="$2"
+  local -r use_public_hostname="$3"
+
+  log_info "Calculating rally point for ASG $asg_name in $aws_region"
+
+  local instances
+  log_info "Waiting for all instances to be available..."
+  instances=$(aws_wrapper_wait_for_instances_in_asg $asg_name $aws_region)
+  assert_not_empty_or_null "$instances" "Wait for instances in ASG $asg_name in $aws_region"
+
+  local rally_point
+  rally_point=$(echo "$instances" | jq -r '[.Reservations[].Instances[]] | sort_by(.LaunchTime, .InstanceId) | .[0]')
+  assert_not_empty_or_null "$rally_point" "Select rally point server in ASG $asg_name"
+
+  local hostname_field=".PrivateDnsName"
+  if [[ "$use_public_hostname" == "true" ]]; then
+    hostname_field=".PublicDnsName"
+  fi
+
+  log_info "Hostname field is $hostname_field"
+
+  local hostname
+  hostname=$(echo "$rally_point" | jq -r "$hostname_field")
+  assert_not_empty_or_null "$hostname" "Get hostname from field $hostname_field for rally point in $asg_name: $rally_point"
+  
+  echo -n "$hostname"
+}

--- a/test/aws-wrapper.bats
+++ b/test/aws-wrapper.bats
@@ -1314,11 +1314,11 @@ END_HEREDOC
 }
 
 function setup_rally_point_by_instance {
-  local readonly asg_name="$1"
-  local readonly aws_region="$2"
-  local readonly size=3
+  local -r asg_name="$1"
+  local -r aws_region="$2"
+  local -r size=3
 
-  local readonly asg=$(cat <<END_HEREDOC
+  local -r asg=$(cat <<END_HEREDOC
 {
     "AutoScalingGroups": [
         {
@@ -1338,7 +1338,7 @@ function setup_rally_point_by_instance {
 END_HEREDOC
 )
 
-  local readonly instances=$(cat <<END_HEREDOC
+  local -r instances=$(cat <<END_HEREDOC
 {
   "Reservations": [
     {
@@ -1400,8 +1400,8 @@ END_HEREDOC
 }
 
 @test "aws_wrapper_get_asg_rally_point by instance id, private" {
-  local readonly asg_name="foo"
-  local readonly aws_region="us-west-2"
+  local -r asg_name="foo"
+  local -r aws_region="us-west-2"
 
   setup_rally_point_by_instance $asg_name $aws_region
 
@@ -1410,13 +1410,11 @@ END_HEREDOC
   out=$(aws_wrapper_get_asg_rally_point $asg_name $aws_region)
   assert_success
   assert_equal "$out" "ip-10-251-50-12.ec2.internal"
-
 }
 
 @test "aws_wrapper_get_asg_rally_point by instance id, public" {
-  local readonly asg_name="foo"
-  local readonly size=3
-  local readonly aws_region="us-west-2"
+  local -r asg_name="foo"
+  local -r aws_region="us-west-2"
 
   setup_rally_point_by_instance $asg_name $aws_region
 
@@ -1425,15 +1423,14 @@ END_HEREDOC
   out=$(aws_wrapper_get_asg_rally_point $asg_name $aws_region true)
   assert_success
   assert_equal "$out" "ec2-203-0-113-25.compute-1.amazonaws.com"
-
 }
 
 function setup_rally_point_by_launch_time {
-  local readonly asg_name="$1"
-  local readonly aws_region="$2"
-  local readonly size=3
+  local -r asg_name="$1"
+  local -r aws_region="$2"
+  local -r size=3
 
-  local readonly asg=$(cat <<END_HEREDOC
+  local -r asg=$(cat <<END_HEREDOC
 {
     "AutoScalingGroups": [
         {
@@ -1453,7 +1450,7 @@ function setup_rally_point_by_launch_time {
 END_HEREDOC
 )
 
-local readonly instances=$(cat <<END_HEREDOC
+local -r instances=$(cat <<END_HEREDOC
 {
   "Reservations": [
     {
@@ -1515,8 +1512,8 @@ END_HEREDOC
 }
 
 @test "aws_wrapper_get_asg_rally_point by launch time, private" {
-  local readonly asg_name="foo"
-  local readonly aws_region="us-west-2"
+  local -r asg_name="foo"
+  local -r aws_region="us-west-2"
 
   setup_rally_point_by_launch_time $asg_name $aws_region
 
@@ -1525,12 +1522,11 @@ END_HEREDOC
   out=$(aws_wrapper_get_asg_rally_point $asg_name $aws_region)
   assert_success
   assert_equal "$out" "ip-10-251-50-122.ec2.internal"
-
 }
 
 @test "aws_wrapper_get_asg_rally_point by launch time, public" {
-  local readonly asg_name="foo"
-  local readonly aws_region="us-west-2"
+  local -r asg_name="foo"
+  local -r aws_region="us-west-2"
 
   setup_rally_point_by_launch_time $asg_name $aws_region
 
@@ -1539,5 +1535,4 @@ END_HEREDOC
   out=$(aws_wrapper_get_asg_rally_point $asg_name $aws_region true)
   assert_success
   assert_equal "$out" "ec2-203-0-113-253.compute-1.amazonaws.com"
-
 }

--- a/test/aws-wrapper.bats
+++ b/test/aws-wrapper.bats
@@ -1313,10 +1313,10 @@ END_HEREDOC
   assert_equal "ip-10-251-50-12.ec2.internal" "$out"
 }
 
-@test "aws_wrapper_get_asg_rally_point by_instance_id" {
-  local readonly asg_name="foo"
+function setup_rally_point_by_instance {
+  local readonly asg_name="$1"
+  local readonly aws_region="$2"
   local readonly size=3
-  local readonly aws_region="us-west-2"
 
   local readonly asg=$(cat <<END_HEREDOC
 {
@@ -1397,6 +1397,13 @@ END_HEREDOC
 )
 
   load_aws_mock "" "$asg" "$instances"
+}
+
+@test "aws_wrapper_get_asg_rally_point by instance id, private" {
+  local readonly asg_name="foo"
+  local readonly aws_region="us-west-2"
+
+  setup_rally_point_by_instance $asg_name $aws_region
 
   local out
 
@@ -1404,16 +1411,27 @@ END_HEREDOC
   assert_success
   assert_equal "$out" "ip-10-251-50-12.ec2.internal"
 
+}
+
+@test "aws_wrapper_get_asg_rally_point by instance id, public" {
+  local readonly asg_name="foo"
+  local readonly size=3
+  local readonly aws_region="us-west-2"
+
+  setup_rally_point_by_instance $asg_name $aws_region
+
+  local out
+
   out=$(aws_wrapper_get_asg_rally_point $asg_name $aws_region true)
   assert_success
   assert_equal "$out" "ec2-203-0-113-25.compute-1.amazonaws.com"
 
 }
 
-@test "aws_wrapper_get_asg_rally_point by_launch_time" {
-  local readonly asg_name="foo"
+function setup_rally_point_by_launch_time {
+  local readonly asg_name="$1"
+  local readonly aws_region="$2"
   local readonly size=3
-  local readonly aws_region="us-west-2"
 
   local readonly asg=$(cat <<END_HEREDOC
 {
@@ -1435,7 +1453,7 @@ END_HEREDOC
 END_HEREDOC
 )
 
-  local readonly instances=$(cat <<END_HEREDOC
+local readonly instances=$(cat <<END_HEREDOC
 {
   "Reservations": [
     {
@@ -1494,12 +1512,29 @@ END_HEREDOC
 )
 
   load_aws_mock "" "$asg" "$instances"
+}
+
+@test "aws_wrapper_get_asg_rally_point by launch time, private" {
+  local readonly asg_name="foo"
+  local readonly aws_region="us-west-2"
+
+  setup_rally_point_by_launch_time $asg_name $aws_region
 
   local out
 
   out=$(aws_wrapper_get_asg_rally_point $asg_name $aws_region)
   assert_success
   assert_equal "$out" "ip-10-251-50-122.ec2.internal"
+
+}
+
+@test "aws_wrapper_get_asg_rally_point by launch time, public" {
+  local readonly asg_name="foo"
+  local readonly aws_region="us-west-2"
+
+  setup_rally_point_by_launch_time $asg_name $aws_region
+
+  local out
 
   out=$(aws_wrapper_get_asg_rally_point $asg_name $aws_region true)
   assert_success

--- a/test/aws-wrapper.bats
+++ b/test/aws-wrapper.bats
@@ -1312,3 +1312,197 @@ END_HEREDOC
   assert_success
   assert_equal "ip-10-251-50-12.ec2.internal" "$out"
 }
+
+@test "aws_wrapper_get_asg_rally_point by_instance_id" {
+  local readonly asg_name="foo"
+  local readonly size=3
+  local readonly aws_region="us-west-2"
+
+  local readonly asg=$(cat <<END_HEREDOC
+{
+    "AutoScalingGroups": [
+        {
+            "AutoScalingGroupARN": "arn:aws:autoscaling:us-west-2:123456789012:autoScalingGroup:930d940e-891e-4781-a11a-7b0acd480f03:autoScalingGroupName/$asg_name",
+            "DesiredCapacity": $size,
+            "AutoScalingGroupName": "$asg_name",
+            "MinSize": 0,
+            "MaxSize": 10,
+            "LaunchConfigurationName": "my-launch-config",
+            "CreatedTime": "2013-08-19T20:53:25.584Z",
+            "AvailabilityZones": [
+                "${aws_region}c"
+            ]
+        }
+    ]
+}
+END_HEREDOC
+)
+
+  local readonly instances=$(cat <<END_HEREDOC
+{
+  "Reservations": [
+    {
+      "Instances": [
+        {
+          "LaunchTime": "2013-08-19T20:53:25.584Z",
+          "InstanceId": "i-1234567890abcdef0",
+          "PublicIpAddress": "55.66.77.88",
+          "PrivateIpAddress": "11.22.33.44",
+          "PrivateDnsName": "ip-10-251-50-12.ec2.internal",
+          "PublicDnsName": "ec2-203-0-113-25.compute-1.amazonaws.com",
+          "Tags": [
+            {
+              "Value": "$asg_name",
+              "Key": "aws:autoscaling:groupName"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Instances": [
+        {
+          "LaunchTime": "2013-08-19T20:53:25.584Z",
+          "InstanceId": "i-1234567890abcdef1",
+          "PublicIpAddress": "55.66.77.881",
+          "PrivateIpAddress": "11.22.33.441",
+          "PrivateDnsName": "ip-10-251-50-121.ec2.internal",
+          "PublicDnsName": "ec2-203-0-113-252.compute-1.amazonaws.com",
+          "Tags": [
+            {
+              "Value": "$asg_name",
+              "Key": "aws:autoscaling:groupName"
+            }
+          ]
+        },
+        {
+          "LaunchTime": "2013-08-19T20:53:25.584Z",
+          "InstanceId": "i-1234567890abcdef2",
+          "PublicIpAddress": "55.66.77.882",
+          "PrivateIpAddress": "11.22.33.442",
+          "PrivateDnsName": "ip-10-251-50-122.ec2.internal",
+          "PublicDnsName": "ec2-203-0-113-253.compute-1.amazonaws.com",
+          "Tags": [
+            {
+              "Value": "$asg_name",
+              "Key": "aws:autoscaling:groupName"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+END_HEREDOC
+)
+
+  load_aws_mock "" "$asg" "$instances"
+
+  local out
+
+  out=$(aws_wrapper_get_asg_rally_point $asg_name $aws_region)
+  assert_success
+  assert_equal "$out" "ip-10-251-50-12.ec2.internal"
+
+  out=$(aws_wrapper_get_asg_rally_point $asg_name $aws_region true)
+  assert_success
+  assert_equal "$out" "ec2-203-0-113-25.compute-1.amazonaws.com"
+
+}
+
+@test "aws_wrapper_get_asg_rally_point by_launch_time" {
+  local readonly asg_name="foo"
+  local readonly size=3
+  local readonly aws_region="us-west-2"
+
+  local readonly asg=$(cat <<END_HEREDOC
+{
+    "AutoScalingGroups": [
+        {
+            "AutoScalingGroupARN": "arn:aws:autoscaling:us-west-2:123456789012:autoScalingGroup:930d940e-891e-4781-a11a-7b0acd480f03:autoScalingGroupName/$asg_name",
+            "DesiredCapacity": $size,
+            "AutoScalingGroupName": "$asg_name",
+            "MinSize": 0,
+            "MaxSize": 10,
+            "LaunchConfigurationName": "my-launch-config",
+            "CreatedTime": "2013-08-19T20:53:25.584Z",
+            "AvailabilityZones": [
+                "${aws_region}c"
+            ]
+        }
+    ]
+}
+END_HEREDOC
+)
+
+  local readonly instances=$(cat <<END_HEREDOC
+{
+  "Reservations": [
+    {
+      "Instances": [
+        {
+          "LaunchTime": "2013-08-19T20:53:25.584Z",
+          "InstanceId": "i-1234567890abcdef0",
+          "PublicIpAddress": "55.66.77.88",
+          "PrivateIpAddress": "11.22.33.44",
+          "PrivateDnsName": "ip-10-251-50-12.ec2.internal",
+          "PublicDnsName": "ec2-203-0-113-25.compute-1.amazonaws.com",
+          "Tags": [
+            {
+              "Value": "$asg_name",
+              "Key": "aws:autoscaling:groupName"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Instances": [
+        {
+          "LaunchTime": "2013-08-19T20:53:25.584Z",
+          "InstanceId": "i-1234567890abcdef1",
+          "PublicIpAddress": "55.66.77.881",
+          "PrivateIpAddress": "11.22.33.441",
+          "PrivateDnsName": "ip-10-251-50-121.ec2.internal",
+          "PublicDnsName": "ec2-203-0-113-252.compute-1.amazonaws.com",
+          "Tags": [
+            {
+              "Value": "$asg_name",
+              "Key": "aws:autoscaling:groupName"
+            }
+          ]
+        },
+        {
+          "LaunchTime": "2013-08-19T20:53:24.584Z",
+          "InstanceId": "i-1234567890abcdef2",
+          "PublicIpAddress": "55.66.77.882",
+          "PrivateIpAddress": "11.22.33.442",
+          "PrivateDnsName": "ip-10-251-50-122.ec2.internal",
+          "PublicDnsName": "ec2-203-0-113-253.compute-1.amazonaws.com",
+          "Tags": [
+            {
+              "Value": "$asg_name",
+              "Key": "aws:autoscaling:groupName"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+END_HEREDOC
+)
+
+  load_aws_mock "" "$asg" "$instances"
+
+  local out
+
+  out=$(aws_wrapper_get_asg_rally_point $asg_name $aws_region)
+  assert_success
+  assert_equal "$out" "ip-10-251-50-122.ec2.internal"
+
+  out=$(aws_wrapper_get_asg_rally_point $asg_name $aws_region true)
+  assert_success
+  assert_equal "$out" "ec2-203-0-113-253.compute-1.amazonaws.com"
+
+}


### PR DESCRIPTION
Fixes #32 as well as updating the Dockerfiles used for testing to use Python 3 (I could not get them to run using the older Python version).

