### PR TITLE
Fix build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,3 +55,4 @@ workflows:
             - Gruntwork Admin
       - bats_ubuntu1604
       - bats_ubuntu1804
+      - bats_ubuntu2004

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     machine: true
     steps:
       - checkout
-      - run: docker-compose up shellcheck --exit-code-from shellcheck
+      - run: docker-compose up --exit-code-from shellcheck shellcheck
   integration_test:
     docker:
       - image: 087285199408.dkr.ecr.us-east-1.amazonaws.com/circle-ci-test-image-base:go1.14

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     machine: true
     steps:
       - checkout
-      - run: docker-compose up shellcheck
+      - run: docker-compose up shellcheck --exit-code-from shellcheck
   integration_test:
     docker:
       - image: 087285199408.dkr.ecr.us-east-1.amazonaws.com/circle-ci-test-image-base:go1.14

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,14 +29,22 @@ jobs:
     machine: true
     steps:
       - checkout
-      - run: docker-compose up bats_ubuntu1604
+      - run: docker-compose up --exit-code-from bats_ubuntu1604 bats_ubuntu1604
   bats_ubuntu1804:
     # We need to run Docker Compose with privileged settings, which isn't supported by CircleCI's Docker executor, so
     # we have to use the machine executor instead.
     machine: true
     steps:
       - checkout
-      - run: docker-compose up bats_ubuntu1804
+      - run: docker-compose up --exit-code-from bats_ubuntu1804 bats_ubuntu1804
+  bats_ubuntu2004:
+    # We need to run Docker Compose with privileged settings, which isn't supported by CircleCI's Docker executor, so
+    # we have to use the machine executor instead.
+    machine: true
+    steps:
+      - checkout
+      - run: docker-compose up --exit-code-from bats_ubuntu2004 bats_ubuntu2004
+
 workflows:
   version: 2
   checks:

--- a/Dockerfile.ubuntu16.04.bats
+++ b/Dockerfile.ubuntu16.04.bats
@@ -3,17 +3,16 @@ MAINTAINER Gruntwork <info@gruntwork.io>
 
 # Install basic dependencies
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
-    apt-get install -y vim python-pip jq sudo curl libffi-dev python3-dev && \
+    apt-get install -y vim git python-pip jq sudo curl libffi-dev python3-dev && \
     update-alternatives --install /usr/bin/python python /usr/bin/python3 1 && \
     update-alternatives --config python && \
     curl https://bootstrap.pypa.io/pip/3.5/get-pip.py -o /tmp/get-pip.py && \
     python /tmp/get-pip.py
 
 # Install Bats
-RUN apt-get install -y software-properties-common && \
-    add-apt-repository ppa:duggan/bats && \
-    DEBIAN_FRONTEND=noninteractive apt-get update && \
-    apt-get install -y bats
+RUN git clone https://github.com/bats-core/bats-core.git /tmp/bats-core && \
+    /tmp/bats-core/install.sh /usr/local && \
+    rm -r /tmp/bats-core
 
 # Upgrade pip
 RUN pip install -U pip
@@ -25,13 +24,13 @@ RUN pip install awscli --upgrade --user
 RUN pip install flask moto moto[server] networkx==2.2
 
 # Install tools we'll need to create a mock EC2 metadata server
-RUN apt-get install -y net-tools iptables
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y net-tools iptables
 
 # Copy mock AWS CLI into the PATH
 COPY ./.circleci/aws-local.sh /usr/local/bin/aws
 
-# These have been added to resolve some encoding error issues with the tests. These were introduced during the upgrade to Python 3.6, 
-# which is known to have some sensitivity around locale issues. These variables should correct that, per examples like this SO thread: 
+# These have been added to resolve some encoding error issues with the tests. These were introduced during the upgrade to Python 3.6,
+# which is known to have some sensitivity around locale issues. These variables should correct that, per examples like this SO thread:
 # https://stackoverflow.com/questions/51026315/how-to-solve-unicodedecodeerror-in-python-3-6/51027262#51027262.
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8

--- a/Dockerfile.ubuntu18.04.bats
+++ b/Dockerfile.ubuntu18.04.bats
@@ -2,35 +2,32 @@ FROM ubuntu:18.04
 MAINTAINER Gruntwork <info@gruntwork.io>
 
 # Install basic dependencies
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
-    apt-get install -y vim python-pip jq sudo curl libffi-dev python3-dev
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y git vim python3-pip jq sudo curl libffi-dev python3-dev
 
 # Install Bats
-RUN apt-get install -y software-properties-common && \
-    add-apt-repository ppa:duggan/bats && \
-    DEBIAN_FRONTEND=noninteractive apt-get update && \
-    apt-get install -y bats
+RUN git clone https://github.com/bats-core/bats-core.git /tmp/bats-core && \
+    /tmp/bats-core/install.sh /usr/local && \
+    rm -r /tmp/bats-core
+
+# Upgrade pip
+RUN pip3 install -U pip
 
 # Install AWS CLI
-RUN apt install python3-distutils python3-apt -y && \
-    update-alternatives --install /usr/bin/python python /usr/bin/python3 1 && \
-    update-alternatives --config python && \
-    curl https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py && \
-    python /tmp/get-pip.py && \
-    pip install awscli --upgrade --user
+RUN pip3 install awscli --upgrade --user
 
 # Install moto: https://github.com/spulec/moto
 # Lock cfn-lint and pysistent to last known working versions
-RUN pip install flask moto moto[server] cfn-lint==0.35.1 pyrsistent==0.16.0
+RUN pip3 install flask moto moto[server] cfn-lint==0.35.1 pyrsistent==0.16.0
 
 # Install tools we'll need to create a mock EC2 metadata server
-RUN apt-get install -y net-tools iptables
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y net-tools iptables
 
 # Copy mock AWS CLI into the PATH
 COPY ./.circleci/aws-local.sh /usr/local/bin/aws
 
-# These have been added to resolve some encoding error issues with the tests. These were introduced during the upgrade to Python 3.6, 
-# which is known to have some sensitivity around locale issues. These variables should correct that, per examples like this SO thread: 
+# These have been added to resolve some encoding error issues with the tests. These were introduced during the upgrade to Python 3.6,
+# which is known to have some sensitivity around locale issues. These variables should correct that, per examples like this SO thread:
 # https://stackoverflow.com/questions/51026315/how-to-solve-unicodedecodeerror-in-python-3-6/51027262#51027262.
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8

--- a/Dockerfile.ubuntu20.04.bats
+++ b/Dockerfile.ubuntu20.04.bats
@@ -2,29 +2,26 @@ FROM ubuntu:20.04
 MAINTAINER Gruntwork <info@gruntwork.io>
 
 # Install basic dependencies
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
-    apt-get install -y vim python-pip jq sudo curl libffi-dev python3-dev
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y git vim python3-pip jq sudo curl libffi-dev python3-dev
 
 # Install Bats
-RUN apt-get install -y software-properties-common && \
-    add-apt-repository ppa:duggan/bats && \
-    DEBIAN_FRONTEND=noninteractive apt-get update && \
-    apt-get install -y bats
+RUN git clone https://github.com/bats-core/bats-core.git /tmp/bats-core && \
+    /tmp/bats-core/install.sh /usr/local && \
+    rm -r /tmp/bats-core
+
+# Upgrade pip
+RUN pip3 install -U pip
 
 # Install AWS CLI
-RUN apt install python3-distutils python3-apt -y && \
-    update-alternatives --install /usr/bin/python python /usr/bin/python3 1 && \
-    update-alternatives --config python && \
-    curl https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py && \
-    python /tmp/get-pip.py && \
-    pip install awscli --upgrade --user
+RUN pip3 install awscli --upgrade --user
 
 # Install moto: https://github.com/spulec/moto
 # Lock cfn-lint and pysistent to last known working versions
-RUN pip install flask moto moto[server] cfn-lint==0.35.1 pyrsistent==0.16.0
+RUN pip3 install flask moto moto[server] cfn-lint==0.35.1 pyrsistent==0.16.0
 
 # Install tools we'll need to create a mock EC2 metadata server
-RUN apt-get install -y net-tools iptables
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y net-tools iptables
 
 # Copy mock AWS CLI into the PATH
 COPY ./.circleci/aws-local.sh /usr/local/bin/aws

--- a/Dockerfile.ubuntu20.04.bats
+++ b/Dockerfile.ubuntu20.04.bats
@@ -1,0 +1,36 @@
+FROM ubuntu:20.04
+MAINTAINER Gruntwork <info@gruntwork.io>
+
+# Install basic dependencies
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
+    apt-get install -y vim python-pip jq sudo curl libffi-dev python3-dev
+
+# Install Bats
+RUN apt-get install -y software-properties-common && \
+    add-apt-repository ppa:duggan/bats && \
+    DEBIAN_FRONTEND=noninteractive apt-get update && \
+    apt-get install -y bats
+
+# Install AWS CLI
+RUN apt install python3-distutils python3-apt -y && \
+    update-alternatives --install /usr/bin/python python /usr/bin/python3 1 && \
+    update-alternatives --config python && \
+    curl https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py && \
+    python /tmp/get-pip.py && \
+    pip install awscli --upgrade --user
+
+# Install moto: https://github.com/spulec/moto
+# Lock cfn-lint and pysistent to last known working versions
+RUN pip install flask moto moto[server] cfn-lint==0.35.1 pyrsistent==0.16.0
+
+# Install tools we'll need to create a mock EC2 metadata server
+RUN apt-get install -y net-tools iptables
+
+# Copy mock AWS CLI into the PATH
+COPY ./.circleci/aws-local.sh /usr/local/bin/aws
+
+# These have been added to resolve some encoding error issues with the tests. These were introduced during the upgrade to Python 3.6,
+# which is known to have some sensitivity around locale issues. These variables should correct that, per examples like this SO thread:
+# https://stackoverflow.com/questions/51026315/how-to-solve-unicodedecodeerror-in-python-3-6/51027262#51027262.
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,3 +30,14 @@ services:
     command: bats test
     # Necessary so we can run a mock EC2 metadata service on port 80 on a special IP
     privileged: true
+  bats_ubuntu2004:
+    build:
+      context: ./
+      dockerfile: Dockerfile.ubuntu20.04.bats
+    volumes:
+      # Mount all the files so you have "hot reload" of all changes from the host
+      - ./:/usr/local/src/bash-commons
+    working_dir: /usr/local/src/bash-commons
+    command: bats test
+    # Necessary so we can run a mock EC2 metadata service on port 80 on a special IP
+    privileged: true

--- a/modules/bash-commons/src/os.sh
+++ b/modules/bash-commons/src/os.sh
@@ -105,7 +105,7 @@ function os_create_user {
     log_info "User $username already exists. Will not create again."
   else
     log_info "Creating user named $username"
-    "$exuseradd" "$username"
+    $exuseradd "$username"
   fi
 }
 
@@ -121,5 +121,5 @@ function os_change_dir_owner {
   fi
 
   log_info "Changing ownership of $dir to $username"
-  "$exchown" -R "$username:$username" "$dir"
+  $exchown -R "$username:$username" "$dir"
 }

--- a/test/aws-cli.bats
+++ b/test/aws-cli.bats
@@ -16,7 +16,7 @@ function teardown {
   run aws_get_instance_tags "fake-id" "us-east-1"
   assert_success
 
-  local readonly expected=$(cat <<END_HEREDOC
+  local -r expected=$(cat <<END_HEREDOC
 {
   "Tags": []
 }
@@ -27,8 +27,8 @@ END_HEREDOC
 }
 
 @test "aws_get_instance_tags non-empty" {
-  local readonly tag_key="foo"
-  local readonly tag_value="bar"
+  local -r tag_key="foo"
+  local -r tag_value="bar"
 
   local instance_id
   instance_id=$(create_mock_instance_with_tags "$tag_key" "$tag_value")
@@ -36,7 +36,7 @@ END_HEREDOC
   run aws_get_instance_tags "$instance_id" "us-east-1"
   assert_success
 
-  local readonly expected=$(cat <<END_HEREDOC
+  local -r expected=$(cat <<END_HEREDOC
 {
    "Tags": [
      {
@@ -72,7 +72,7 @@ END_HEREDOC
   run aws_describe_asg "fake-asg-name" "us-east-1"
   assert_success
 
-  local readonly expected=$(cat <<END_HEREDOC
+  local -r expected=$(cat <<END_HEREDOC
 {
   "AutoScalingGroups": []
 }
@@ -82,12 +82,23 @@ END_HEREDOC
   assert_output_json "$expected"
 }
 
+# not ok 61 aws_describe_asg non-empty
+# (from function `create_mock_asg' in file test/aws-helper.bash, line 141,
+#  in test file test/aws-cli.bats, line 92)
+#   `create_mock_asg "$asg_name" "$min_size" "$max_size" "$azs"' failed with status 255
+#  * Running on http://127.0.0.1:5000/ (Press CTRL+C to quit)
+# 127.0.0.1 - - [10/Jun/2021 19:42:02] "POST / HTTP/1.1" 400 -
+#
+# An error occurred (ValidationError) when calling the CreateLaunchConfiguration operation: Valid requests must contain either the InstanceID parameter or both the ImageId and InstanceType pa
+
+# Received signal 15
+
 @test "aws_describe_asg non-empty" {
-  local readonly asg_name="foo"
-  local readonly min_size=1
-  local readonly max_size=3
-  local readonly region="us-east-1"
-  local readonly azs="${region}a"
+  local -r asg_name="foo"
+  local -r min_size=1
+  local -r max_size=3
+  local -r region="us-east-1"
+  local -r azs="${region}a"
 
   create_mock_asg "$asg_name" "$min_size" "$max_size" "$azs"
 
@@ -111,7 +122,7 @@ END_HEREDOC
   run aws_describe_instances_in_asg "fake-asg-name" "us-east-1"
   assert_success
 
-  local readonly expected=$(cat <<END_HEREDOC
+  local -r expected=$(cat <<END_HEREDOC
 {
   "Reservations": []
 }
@@ -122,11 +133,11 @@ END_HEREDOC
 }
 
 @test "aws_describe_instances_in_asg non-empty" {
-  local readonly asg_name="foo"
-  local readonly min_size=1
-  local readonly max_size=3
-  local readonly region="us-east-1"
-  local readonly azs="${region}a"
+  local -r asg_name="foo"
+  local -r min_size=1
+  local -r max_size=3
+  local -r region="us-east-1"
+  local -r azs="${region}a"
 
   create_mock_asg "$asg_name" "$min_size" "$max_size" "$azs"
 
@@ -142,7 +153,7 @@ END_HEREDOC
   run aws_get_instances_with_tag "Name" "Value" "us-east-1"
   assert_success
 
-  local readonly expected=$(cat <<END_HEREDOC
+  local -r expected=$(cat <<END_HEREDOC
 {
   "Reservations": []
 }

--- a/test/aws-cli.bats
+++ b/test/aws-cli.bats
@@ -82,17 +82,6 @@ END_HEREDOC
   assert_output_json "$expected"
 }
 
-# not ok 61 aws_describe_asg non-empty
-# (from function `create_mock_asg' in file test/aws-helper.bash, line 141,
-#  in test file test/aws-cli.bats, line 92)
-#   `create_mock_asg "$asg_name" "$min_size" "$max_size" "$azs"' failed with status 255
-#  * Running on http://127.0.0.1:5000/ (Press CTRL+C to quit)
-# 127.0.0.1 - - [10/Jun/2021 19:42:02] "POST / HTTP/1.1" 400 -
-#
-# An error occurred (ValidationError) when calling the CreateLaunchConfiguration operation: Valid requests must contain either the InstanceID parameter or both the ImageId and InstanceType pa
-
-# Received signal 15
-
 @test "aws_describe_asg non-empty" {
   local -r asg_name="foo"
   local -r min_size=1

--- a/test/aws-helper.bash
+++ b/test/aws-helper.bash
@@ -19,7 +19,7 @@ function start_ec2_metadata_mock {
   export meta_data_local_hostname="$3"
   export meta_data_public_hostname="$4"
   export meta_data_instance_id="$5"
-  local readonly region="$6"
+  local -r region="$6"
   export meta_data_placement__availability_zone="$7"
   export dynamic_data_instance_identity__document=$(cat <<END_HEREDOC
 {
@@ -71,7 +71,7 @@ END_HEREDOC
 function stop_ec2_metadata_mock {
   # Stop ec2-metadata-mock if it's running
   if [[ -f "$EC2_METADATA_MOCK_PID_PATH" ]]; then
-    local readonly pid=$(cat "$EC2_METADATA_MOCK_PID_PATH")
+    local -r pid=$(cat "$EC2_METADATA_MOCK_PID_PATH")
     kill "$pid" 2>&1 > "$EC2_METADATA_MOCK_LOG_FILE_PATH"
     rm -f "$EC2_METADATA_MOCK_PID_PATH"
 
@@ -108,7 +108,7 @@ function start_moto {
 function stop_moto {
   # Stop moto if it's running
   if [[ -f "$MOTO_PID_FILE_PATH" ]]; then
-    local readonly pid=$(cat "$MOTO_PID_FILE_PATH")
+    local -r pid=$(cat "$MOTO_PID_FILE_PATH")
     kill "$pid" 2>&1 > /dev/null
     rm -f "$MOTO_PID_FILE_PATH"
 
@@ -118,8 +118,8 @@ function stop_moto {
 }
 
 function create_mock_instance_with_tags {
-  local readonly tag_key="$1"
-  local readonly tag_value="$2"
+  local -r tag_key="$1"
+  local -r tag_value="$2"
 
   local mock_instance
   mock_instance=$(aws ec2 run-instances)
@@ -133,11 +133,11 @@ function create_mock_instance_with_tags {
 }
 
 function create_mock_asg {
-  local readonly asg_name="$1"
-  local readonly min_size="$2"
-  local readonly max_size="$3"
-  local readonly azs="$4"
+  local -r asg_name="$1"
+  local -r min_size="$2"
+  local -r max_size="$3"
+  local -r azs="$4"
 
-  aws autoscaling create-launch-configuration --launch-configuration-name "$asg_name"
+  aws autoscaling create-launch-configuration --launch-configuration-name "$asg_name" --image-id ami-fake --instance-type t3.micro
   aws autoscaling create-auto-scaling-group --auto-scaling-group-name "$asg_name" --min-size "$min_size" --max-size "$max_size" --availability-zones "$azs" --launch-configuration-name "$asg_name"
 }

--- a/test/aws-wrapper.bats
+++ b/test/aws-wrapper.bats
@@ -255,25 +255,7 @@ END_HEREDOC
 
   load_aws_mock "$tags" "" ""
 
-  run naws_wrapper_wait_for_instance_tags "i-1234567890abcdef0" "us-east-1" "$max_retries" "$sleep_between_retries"
-
-  assert_failure
-}
-
-@test "aws_wrapper_wait_for_instance_tags no tags" {
-  local reaodnly max_retries=1
-  local readonly sleep_between_retries=0
-  local readonly tags=$(cat <<END_HEREDOC
-{
-   "Tags": []
- }
-END_HEREDOC
-)
-
-  load_aws_mock "$tags" "" ""
-
-  run naws_wrapper_wait_for_instance_tags "i-1234567890abcdef0" "us-east-1" "$max_retries" "$sleep_between_retries"
-
+  run aws_wrapper_wait_for_instance_tags "i-1234567890abcdef0" "us-east-1" "$max_retries" "$sleep_between_retries"
   assert_failure
 }
 

--- a/test/os.bats
+++ b/test/os.bats
@@ -98,6 +98,17 @@ load "test-helper"
   assert_success
 }
 
+@test "os_create_user with sudo for new_user_sudo user" {
+  local suffix
+  suffix=$(date +%s)
+  local -r username="new_user_sudo$suffix"
+  run os_user_exists "$username"
+  assert_failure
+  run os_create_user "$username" 'true'
+  assert_success
+  run os_user_exists "$username"
+  assert_success
+}
 
 @test "os_change_dir_owner for new_user user" {
   local suffix
@@ -107,6 +118,18 @@ load "test-helper"
   assert_success
   mkdir -p "/tmp/$username"
   os_change_dir_owner "/tmp/$username" "$username"
+  local owner=$(stat -c '%U' "/tmp/$username")
+  assert_equal "$username" "$owner"
+}
+
+@test "os_change_dir_owner with sudo for new_user_sudo user" {
+  local suffix
+  suffix=$(date +%s)
+  local -r username="new_user_sudo$suffix"
+  run os_create_user "$username"
+  assert_success
+  mkdir -p "/tmp/$username"
+  os_change_dir_owner "/tmp/$username" "$username" 'true'
   local owner=$(stat -c '%U' "/tmp/$username")
   assert_equal "$username" "$owner"
 }


### PR DESCRIPTION
This PR includes several fixes:

- Add a regression test for sudo functionality for user mod functions introduced in https://github.com/gruntwork-io/bash-commons/pull/35.
- Added testing for Ubuntu 20.04
- Fix test pipeline such that error codes are propagated. Before, circleci would **always be green** even if the bats tests failed!
- Fix the failing tests that were revealed from updating the test pipeline.
- Fix bug in sudo functionality for user mod functions.
- `s/local readonly/local -r/g`

I know this is a lot, so if necessary, I can break up the PR to separate out the fixes.