### PR TITLE
fix documentation discrepancy with IMDS version

### DIFF
--- a/modules/bash-commons/src/aws.sh
+++ b/modules/bash-commons/src/aws.sh
@@ -31,7 +31,7 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/log.sh"
 # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html
 #
 # If you prefer to use Instance Metadata service version 2, you can do so by setting the environment variable:
-# export GRUNTWORK_BASH_COMMONS_IMDSV="2"
+# export GRUNTWORK_BASH_COMMONS_IMDS_VERSION="2"
 function aws_get_instance_metadata_version_in_use {
   using=${GRUNTWORK_BASH_COMMONS_IMDS_VERSION:-$default_instance_metadata_version}
   assert_value_in_list "Instance Metadata service version in use" "$using" "1" "2"
@@ -50,7 +50,7 @@ function aws_get_instance_metadata_version_in_use {
 # modules are being updated to use IMDSv2.
 #
 # Version 1 is the default, but can be overridden by setting:
-# env var GRUNTWORK_BASH_COMMONS_IMDSV=2
+# env var GRUNTWORK_BASH_COMMONS_IMDS_VERSION=2
 function aws_lookup_path_in_instance_metadata {
   local -r path="$1"
   version_in_use=$(aws_get_instance_metadata_version_in_use)
@@ -66,7 +66,7 @@ function aws_lookup_path_in_instance_metadata {
 # modules are being updated to use IMDSv2.
 #
 # Version 1 is the default, but can be overridden by setting:
-# env var GRUNTWORK_BASH_COMMONS_IMDSV=2
+# env var GRUNTWORK_BASH_COMMONS_IMDS_VERSION=2
 function aws_lookup_path_in_instance_dynamic_data {
  local -r path="$1"
  version_in_use=$(aws_get_instance_metadata_version_in_use)


### PR DESCRIPTION
## Description

Fixes #54. Update code comment documentation to reflect the correct environment vars needed to set the IMDS version.

### Documentation

<!--
  If this is a feature PR, then where is it documented?

  - If docs exist:
    - Update any references, if relevant.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

<!-- Important: Did you make any backward incompatible changes? If yes, then you must write a migration guide! -->

## TODOs

Please ensure all of these TODOs are completed before asking for a review.

- [x] Ensure the branch is named correctly with the issue number. e.g: `feature/new-vpc-endpoints-955` or `bug/missing-count-param-434`.
- [x] Update the docs.
- [x] Keep the changes backward compatible where possible.
- [x] Run the pre-commit checks successfully.
- [ ] Run the relevant tests successfully.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.