### PR TITLE
bug/RHEL identity update for 8

### DIFF
--- a/modules/bash-commons/src/os.sh
+++ b/modules/bash-commons/src/os.sh
@@ -30,10 +30,10 @@ function os_is_centos {
 }
 
 # Returns true (0) if this is a RedHat server at the given version or false (1) otherwise. The version number
-# can use regex. If you don't care about the version, leave it unspecified.
+# can use regex. If you don't care about the version, leave it unspecified.  RedHat 8+ removed the word "Server".
 function os_is_redhat {
   local -r version="$1"
-  grep -q "Red Hat Enterprise Linux Server release $version" /etc/*release
+  grep -q "Red Hat Enterprise Linux release $version" /etc/*release || grep -q "Red Hat Enterprise Linux Server release $version" /etc/*release
 }
 
 


### PR DESCRIPTION
RHEL 8 removed the word "Server" from the PRETTY NAME.  This caused RHEL 8 servers to not be able to identify

I probably need to re-submit this with a proper Branch name.  And maybe submit an issue...

## Description

Added the ability of the os_is_redhat function to properly detect RHEL 8.

## TODOs

Please ensure all of these TODOs are completed before asking for a review.

- [ ] Ensure the branch is named correctly with the issue number. e.g: `feature/new-vpc-endpoints-955` or `bug/missing-count-param-434`.
- [ ] Update the docs.
- [ ] Keep the changes backward compatible where possible.
- [ ] Run the pre-commit checks successfully.
- [ ] Run the relevant tests successfully.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.


## Related Issues

<!--
  Link to related issues, and issues fixed or partially addressed by this PR.
  e.g. Fixes #1234
  e.g. Addresses #1234
  e.g. Related to #1234
-->
